### PR TITLE
order-resume 주문 상세보기 & 테스트 코드 작성

### DIFF
--- a/src/main/java/project/forwork/api/domain/order/controller/model/OrderDetailResponse.java
+++ b/src/main/java/project/forwork/api/domain/order/controller/model/OrderDetailResponse.java
@@ -1,0 +1,21 @@
+package project.forwork.api.domain.order.controller.model;
+
+import lombok.*;
+import project.forwork.api.domain.orderresume.controller.model.OrderResumeResponse;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class OrderDetailResponse {
+
+    private Long orderId;
+    private LocalDateTime orderedAt;
+    private String email;
+    private List<OrderResumeResponse> orderResumeResponses;
+    private BigDecimal totalPrice;
+}

--- a/src/main/java/project/forwork/api/domain/order/infrastructure/OrderJpaRepository.java
+++ b/src/main/java/project/forwork/api/domain/order/infrastructure/OrderJpaRepository.java
@@ -5,8 +5,10 @@ import org.springframework.data.jpa.repository.Query;
 import project.forwork.api.domain.order.infrastructure.enums.OrderStatus;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface OrderJpaRepository extends JpaRepository<OrderEntity, Long> {
-
+    Optional<OrderEntity> getByUserEntity_IdAndId(Long userId, Long orderId);
     List<OrderEntity> findAllByStatus(OrderStatus status);
+    List<OrderEntity> findByUserEntity_IdAndStatusInOrderByIdDesc(Long userId, List<OrderStatus> statuses);
 }

--- a/src/main/java/project/forwork/api/domain/order/infrastructure/OrderRepositoryImpl.java
+++ b/src/main/java/project/forwork/api/domain/order/infrastructure/OrderRepositoryImpl.java
@@ -28,17 +28,24 @@ public class OrderRepositoryImpl implements OrderRepository {
     }
 
     @Override
-    public Order getByIdWithThrow(long id) {
-        return findById(id).orElseThrow(() -> new ApiException(OrderErrorCode.ORDER_NOT_FOUND, id));
+    public Order getByIdWithThrow(Long orderId) {
+        return findById(orderId).orElseThrow(() -> new ApiException(OrderErrorCode.ORDER_NOT_FOUND, orderId));
     }
 
     @Override
-    public Optional<Order> findById(long id) {
-        return orderJpaRepository.findById(id).map(OrderEntity::toModel);
+    public Order getOrderWithThrow(Long userId, Long orderId) {
+        return orderJpaRepository.getByUserEntity_IdAndId(userId, orderId)
+                .orElseThrow(() -> new ApiException(OrderErrorCode.ORDER_NOT_FOUND, orderId))
+                .toModel();
     }
 
     @Override
-    public List<Order> findAllByStatus(OrderStatus status) {
+    public Optional<Order> findById(Long orderId) {
+        return orderJpaRepository.findById(orderId).map(OrderEntity::toModel);
+    }
+
+    @Override
+    public List<Order> findByStatus(OrderStatus status) {
         return orderJpaRepository.findAllByStatus(status).stream()
                 .map(OrderEntity::toModel)
                 .toList();

--- a/src/main/java/project/forwork/api/domain/order/infrastructure/enums/OrderStatus.java
+++ b/src/main/java/project/forwork/api/domain/order/infrastructure/enums/OrderStatus.java
@@ -7,9 +7,9 @@ import lombok.AllArgsConstructor;
 public enum OrderStatus {
     ORDER("결제완료"),
     WAIT("발송대기"),
+    PARTIAL_WAIT("부분대기"),
     CANCEL("주문취소"),
     PARTIAL_CANCEL("부분취소"),
-    PARTIAL_WAIT("부분대기"),
     CONFIRM("구매확정"),
     PARTIAL_CONFIRM("부분확정"),
     ;

--- a/src/main/java/project/forwork/api/domain/order/model/Order.java
+++ b/src/main/java/project/forwork/api/domain/order/model/Order.java
@@ -128,4 +128,8 @@ public class Order {
                 .canceledAt(clockHolder.now())
                 .build();
     }
+
+    public String getBuyerEmail(){
+        return user.getEmail();
+    }
 }

--- a/src/main/java/project/forwork/api/domain/order/service/OrderService.java
+++ b/src/main/java/project/forwork/api/domain/order/service/OrderService.java
@@ -10,11 +10,12 @@ import project.forwork.api.common.service.port.ClockHolder;
 import project.forwork.api.domain.cartresume.model.CartResume;
 import project.forwork.api.domain.cartresume.service.port.CartResumeRepository;
 import project.forwork.api.domain.order.controller.model.CancelRequest;
+import project.forwork.api.domain.order.controller.model.OrderDetailResponse;
 import project.forwork.api.domain.order.controller.model.OrderRequest;
 import project.forwork.api.domain.order.infrastructure.enums.OrderStatus;
 import project.forwork.api.domain.order.model.Order;
 import project.forwork.api.domain.order.service.port.OrderRepository;
-import project.forwork.api.domain.orderresume.infrastructure.enums.OrderResumeStatus;
+import project.forwork.api.domain.orderresume.controller.model.OrderResumeResponse;
 import project.forwork.api.domain.orderresume.model.OrderResume;
 import project.forwork.api.domain.orderresume.service.OrderResumeService;
 import project.forwork.api.domain.orderresume.service.port.OrderResumeRepository;
@@ -80,7 +81,7 @@ public class OrderService {
     }
     @Scheduled(fixedRate = 60000) // TODO 시간 변경 페이징처리(do while)
     public void markAsWaiting(){
-        List<Order> orders = orderRepository.findAllByStatus(OrderStatus.ORDER);
+        List<Order> orders = orderRepository.findByStatus(OrderStatus.ORDER);
         orders = orders.stream()
                 .map(order -> order.markAsWaiting(OrderStatus.WAIT)).toList();
         orderRepository.saveAll(orders);
@@ -88,14 +89,14 @@ public class OrderService {
 
     @Scheduled(fixedRate = 60000)
     public void markPartialAsWaiting(){
-        List<Order> partialOrders = orderRepository.findAllByStatus(OrderStatus.PARTIAL_CANCEL);
+        List<Order> partialOrders = orderRepository.findByStatus(OrderStatus.PARTIAL_CANCEL);
         partialOrders = partialOrders.stream()
                 .map(order -> order.markAsWaiting(OrderStatus.PARTIAL_WAIT)).toList();
         orderRepository.saveAll(partialOrders);
     }
     @Scheduled(fixedRate = 70000)
     public void markAsConfirm(){
-        List<Order> orders = orderRepository.findAllByStatus(OrderStatus.WAIT);
+        List<Order> orders = orderRepository.findByStatus(OrderStatus.WAIT);
 
         orders = orders.stream()
                 .map(order -> order.markAsConfirm(OrderStatus.CONFIRM, clockHolder)).toList();
@@ -106,7 +107,7 @@ public class OrderService {
 
     @Scheduled(fixedRate = 70000)
     public void markPartialAsConfirm(){
-        List<Order> partialOrders = orderRepository.findAllByStatus(OrderStatus.PARTIAL_WAIT);
+        List<Order> partialOrders = orderRepository.findByStatus(OrderStatus.PARTIAL_WAIT);
 
         partialOrders = partialOrders.stream()
                 .map(order -> order.markAsConfirm(OrderStatus.PARTIAL_CONFIRM, clockHolder)).toList();
@@ -136,6 +137,21 @@ public class OrderService {
         Order order = orderRepository.getByIdWithThrow(orderId);
         order = order.cancelPartialOrder(currentUser.getId(), orderResumes, clockHolder);
         orderRepository.save(order);
+    }
+
+    public OrderDetailResponse getOrderDetail(CurrentUser currentUser, Long orderId){
+        // 검증로직이 필요하지않은이유 -> currentUser.getId() 자체로 레포에서 조회를 하기때문에
+        // currentUser 인터셉터와 쿠키에 의해 만들어진 검증된 객체
+        Order order = orderRepository.getOrderWithThrow(currentUser.getId(), orderId);
+        List<OrderResumeResponse> orderResumes = orderResumeRepository.findByOrderId(order.getId());
+
+        return OrderDetailResponse.builder()
+                .email(order.getBuyerEmail())
+                .totalPrice(order.getTotalPrice())
+                .orderedAt(order.getOrderedAt())
+                .orderId(order.getId())
+                .orderResumeResponses(orderResumes)
+                .build();
     }
 
     public Order getByIdWithThrow(Long orderId){

--- a/src/main/java/project/forwork/api/domain/order/service/OrderService.java
+++ b/src/main/java/project/forwork/api/domain/order/service/OrderService.java
@@ -16,6 +16,7 @@ import project.forwork.api.domain.order.infrastructure.enums.OrderStatus;
 import project.forwork.api.domain.order.model.Order;
 import project.forwork.api.domain.order.service.port.OrderRepository;
 import project.forwork.api.domain.orderresume.controller.model.OrderResumeResponse;
+import project.forwork.api.domain.orderresume.infrastructure.OrderResumeQueryDslRepository;
 import project.forwork.api.domain.orderresume.model.OrderResume;
 import project.forwork.api.domain.orderresume.service.OrderResumeService;
 import project.forwork.api.domain.orderresume.service.port.OrderResumeRepository;
@@ -47,6 +48,7 @@ public class OrderService {
     private final OrderRepository orderRepository;
     private final CartResumeRepository cartResumeRepository;
     private final OrderResumeRepository orderResumeRepository;
+    private final OrderResumeQueryDslRepository orderResumeQueryDslRepository;
     private final ResumeRepository resumeRepository;
     private final UserRepository userRepository;
     private final ClockHolder clockHolder;
@@ -143,7 +145,7 @@ public class OrderService {
         // 검증로직이 필요하지않은이유 -> currentUser.getId() 자체로 레포에서 조회를 하기때문에
         // currentUser 인터셉터와 쿠키에 의해 만들어진 검증된 객체
         Order order = orderRepository.getOrderWithThrow(currentUser.getId(), orderId);
-        List<OrderResumeResponse> orderResumes = orderResumeRepository.findByOrderId(order.getId());
+        List<OrderResumeResponse> orderResumes = orderResumeQueryDslRepository.findByOrderId(order.getId());
 
         return OrderDetailResponse.builder()
                 .email(order.getBuyerEmail())

--- a/src/main/java/project/forwork/api/domain/order/service/port/OrderRepository.java
+++ b/src/main/java/project/forwork/api/domain/order/service/port/OrderRepository.java
@@ -7,10 +7,10 @@ import java.util.List;
 import java.util.Optional;
 
 public interface OrderRepository {
-
     Order save(Order order);
     void saveAll(List<Order> orders);
-    Order getByIdWithThrow(long id);
-    Optional<Order> findById(long id);
-    List<Order> findAllByStatus(OrderStatus status);
+    Order getByIdWithThrow(Long orderId);
+    Order getOrderWithThrow(Long userId, Long orderId);
+    Optional<Order> findById(Long orderId);
+    List<Order> findByStatus(OrderStatus status);
 }

--- a/src/main/java/project/forwork/api/domain/orderresume/controller/model/OrderResumeResponse.java
+++ b/src/main/java/project/forwork/api/domain/orderresume/controller/model/OrderResumeResponse.java
@@ -1,0 +1,25 @@
+package project.forwork.api.domain.orderresume.controller.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import project.forwork.api.domain.orderresume.infrastructure.enums.OrderResumeStatus;
+import project.forwork.api.domain.resume.infrastructure.enums.FieldType;
+import project.forwork.api.domain.resume.infrastructure.enums.LevelType;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class OrderResumeResponse {
+
+    private Long orderId;
+    private String title;
+    private OrderResumeStatus status;
+    private BigDecimal price;
+    private LocalDateTime orderedAt;
+}

--- a/src/main/java/project/forwork/api/domain/orderresume/infrastructure/OrderResumeJpaRepository.java
+++ b/src/main/java/project/forwork/api/domain/orderresume/infrastructure/OrderResumeJpaRepository.java
@@ -10,6 +10,9 @@ import project.forwork.api.domain.orderresume.infrastructure.enums.OrderResumeSt
 import java.util.List;
 
 public interface OrderResumeJpaRepository extends JpaRepository<OrderResumeEntity, Long> {
+
+    List<OrderResumeEntity> findByOrderEntity_Id(Long orderId);
+
     @Query("select ore from OrderResumeEntity ore" +
             " join fetch ore.orderEntity o" +
             " where o IN :orderEntity" +

--- a/src/main/java/project/forwork/api/domain/orderresume/infrastructure/OrderResumeQueryDslRepository.java
+++ b/src/main/java/project/forwork/api/domain/orderresume/infrastructure/OrderResumeQueryDslRepository.java
@@ -1,6 +1,7 @@
 package project.forwork.api.domain.orderresume.infrastructure;
 
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -8,6 +9,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Repository;
+import project.forwork.api.domain.orderresume.controller.model.OrderResumeResponse;
 import project.forwork.api.domain.orderresume.infrastructure.enums.OrderResumeStatus;
 import project.forwork.api.domain.orderresume.model.PurchaseInfo;
 
@@ -50,5 +52,50 @@ public class OrderResumeQueryDslRepository {
                 .fetch();
 
         return new PageImpl<>(content, pageRequest, content.size());
+    }
+
+    public List<OrderResumeResponse> getByUserIdAndStatus(Long userId, List<OrderResumeStatus> statuses){
+        return queryFactory
+                .select(Projections.fields(OrderResumeResponse.class,
+                        orderEntity.id.as("orderId"),
+                        resumeEntity.price.as("price"),
+                        orderEntity.orderedAt.as("orderedAt"),
+                        orderResumeEntity.status.as("status"),
+                        Expressions.stringTemplate(
+                                "CONCAT({0}, ' ', {1}, ' 이력서 #', {2})",
+                                resumeEntity.levelType.stringValue(),
+                                resumeEntity.fieldType.stringValue(),
+                                resumeEntity.id
+                        ).as("title")
+                ))
+                .from(orderResumeEntity)
+                .join(orderResumeEntity.orderEntity, orderEntity)
+                .join(orderResumeEntity.resumeEntity, resumeEntity)
+                .join(orderEntity.userEntity, userEntity)
+                .where(orderResumeEntity.status.in(statuses))
+                .where(userEntity.id.eq(userId))
+                .orderBy(orderEntity.orderedAt.desc())
+                .fetch();
+    }
+
+    public List<OrderResumeResponse> getByOrderId(Long orderId){
+        return queryFactory
+                .select(Projections.fields(OrderResumeResponse.class,
+                        orderEntity.id.as("orderId"),
+                        resumeEntity.price.as("price"),
+                        orderEntity.orderedAt.as("orderedAt"),
+                        orderResumeEntity.status.as("status"),
+                        Expressions.stringTemplate(
+                                "CONCAT({0}, ' ', {1}, ' 이력서 #', {2})",
+                                resumeEntity.levelType.stringValue(),
+                                resumeEntity.fieldType.stringValue(),
+                                resumeEntity.id
+                        ).as("title")
+                ))
+                .from(orderResumeEntity)
+                .join(orderResumeEntity.orderEntity, orderEntity)
+                .join(orderResumeEntity.resumeEntity, resumeEntity)
+                .where(orderEntity.id.eq(orderId))
+                .fetch();
     }
 }

--- a/src/main/java/project/forwork/api/domain/orderresume/infrastructure/OrderResumeQueryDslRepository.java
+++ b/src/main/java/project/forwork/api/domain/orderresume/infrastructure/OrderResumeQueryDslRepository.java
@@ -29,7 +29,7 @@ public class OrderResumeQueryDslRepository {
         this.queryFactory = new JPAQueryFactory(em);
     }
 
-    public Page<PurchaseInfo> getPurchaseInfo() {
+    public Page<PurchaseInfo> findPurchaseResume() {
 
         PageRequest pageRequest = PageRequest.of(0, 20);
 
@@ -54,7 +54,7 @@ public class OrderResumeQueryDslRepository {
         return new PageImpl<>(content, pageRequest, content.size());
     }
 
-    public List<OrderResumeResponse> getByUserIdAndStatus(Long userId, List<OrderResumeStatus> statuses){
+    public List<OrderResumeResponse> findByUserIdAndStatus(Long userId, List<OrderResumeStatus> statuses){
         return queryFactory
                 .select(Projections.fields(OrderResumeResponse.class,
                         orderEntity.id.as("orderId"),
@@ -78,7 +78,7 @@ public class OrderResumeQueryDslRepository {
                 .fetch();
     }
 
-    public List<OrderResumeResponse> getByOrderId(Long orderId){
+    public List<OrderResumeResponse> findByOrderId(Long orderId){
         return queryFactory
                 .select(Projections.fields(OrderResumeResponse.class,
                         orderEntity.id.as("orderId"),

--- a/src/main/java/project/forwork/api/domain/orderresume/infrastructure/OrderResumeRepositoryImpl.java
+++ b/src/main/java/project/forwork/api/domain/orderresume/infrastructure/OrderResumeRepositoryImpl.java
@@ -3,11 +3,11 @@ package project.forwork.api.domain.orderresume.infrastructure;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Repository;
-import project.forwork.api.common.error.OrderErrorCode;
 import project.forwork.api.common.error.OrderResumeErrorCode;
 import project.forwork.api.common.exception.ApiException;
 import project.forwork.api.domain.order.infrastructure.OrderEntity;
 import project.forwork.api.domain.order.model.Order;
+import project.forwork.api.domain.orderresume.controller.model.OrderResumeResponse;
 import project.forwork.api.domain.orderresume.infrastructure.enums.OrderResumeStatus;
 import project.forwork.api.domain.orderresume.model.OrderResume;
 import project.forwork.api.domain.orderresume.model.PurchaseInfo;
@@ -49,6 +49,10 @@ public class OrderResumeRepositoryImpl implements OrderResumeRepository {
                 .map(OrderResumeEntity::toModel)
                 .toList();
     }
+    @Override
+    public List<OrderResumeResponse> findByOrderId(Long orderId) {
+        return orderResumeQueryDslRepository.getByOrderId(orderId);
+    }
 
     @Override
     public List<OrderResume> findByStatusAndOrder(OrderResumeStatus status, Order order) {
@@ -65,7 +69,12 @@ public class OrderResumeRepositoryImpl implements OrderResumeRepository {
     }
 
     @Override
-    public Page<PurchaseInfo> getPurchaseResume() {
+    public List<OrderResumeResponse> findByUserIdAndStatus(Long userId, List<OrderResumeStatus> statuses) {
+        return orderResumeQueryDslRepository.getByUserIdAndStatus(userId, statuses);
+    }
+
+    @Override
+    public Page<PurchaseInfo> findPurchaseResume() {
         return orderResumeQueryDslRepository.getPurchaseInfo();
     }
 }

--- a/src/main/java/project/forwork/api/domain/orderresume/infrastructure/OrderResumeRepositoryImpl.java
+++ b/src/main/java/project/forwork/api/domain/orderresume/infrastructure/OrderResumeRepositoryImpl.java
@@ -21,7 +21,7 @@ import java.util.Optional;
 public class OrderResumeRepositoryImpl implements OrderResumeRepository {
 
     private final OrderResumeJpaRepository orderResumeJpaRepository;
-    private final OrderResumeQueryDslRepository orderResumeQueryDslRepository;
+
     @Override
     public OrderResume save(OrderResume orderResume) {
         return orderResumeJpaRepository.save(OrderResumeEntity.from(orderResume)).toModel();
@@ -49,10 +49,6 @@ public class OrderResumeRepositoryImpl implements OrderResumeRepository {
                 .map(OrderResumeEntity::toModel)
                 .toList();
     }
-    @Override
-    public List<OrderResumeResponse> findByOrderId(Long orderId) {
-        return orderResumeQueryDslRepository.getByOrderId(orderId);
-    }
 
     @Override
     public List<OrderResume> findByStatusAndOrder(OrderResumeStatus status, Order order) {
@@ -66,15 +62,5 @@ public class OrderResumeRepositoryImpl implements OrderResumeRepository {
         return orderResumeJpaRepository.findByStatusAndOrder(status, orderEntities).stream()
                 .map(OrderResumeEntity::toModel)
                 .toList();
-    }
-
-    @Override
-    public List<OrderResumeResponse> findByUserIdAndStatus(Long userId, List<OrderResumeStatus> statuses) {
-        return orderResumeQueryDslRepository.getByUserIdAndStatus(userId, statuses);
-    }
-
-    @Override
-    public Page<PurchaseInfo> findPurchaseResume() {
-        return orderResumeQueryDslRepository.getPurchaseInfo();
     }
 }

--- a/src/main/java/project/forwork/api/domain/orderresume/model/PurchaseInfo.java
+++ b/src/main/java/project/forwork/api/domain/orderresume/model/PurchaseInfo.java
@@ -3,20 +3,22 @@ package project.forwork.api.domain.orderresume.model;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import project.forwork.api.domain.resume.infrastructure.enums.FieldType;
 import project.forwork.api.domain.resume.infrastructure.enums.LevelType;
 
 @Getter
 @AllArgsConstructor
 @Builder
+@NoArgsConstructor
 public class PurchaseInfo {
 
-    private final Long orderId;
-    private final Long resumeId;
-    private final String email;
-    private final LevelType level;
-    private final FieldType field;
-    private final String resumeUrl;
+    private Long orderId;
+    private Long resumeId;
+    private String email;
+    private LevelType level;
+    private FieldType field;
+    private String resumeUrl;
 
     public String getSalePostTitle(){
         return level.getDescription() + " " + field.getDescription() + " 이력서 #" + getResumeId();

--- a/src/main/java/project/forwork/api/domain/orderresume/service/OrderResumeService.java
+++ b/src/main/java/project/forwork/api/domain/orderresume/service/OrderResumeService.java
@@ -4,8 +4,10 @@ import lombok.Builder;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import project.forwork.api.common.domain.CurrentUser;
 import project.forwork.api.domain.cartresume.model.CartResume;
 import project.forwork.api.domain.order.model.Order;
+import project.forwork.api.domain.orderresume.controller.model.OrderResumeResponse;
 import project.forwork.api.domain.orderresume.infrastructure.enums.OrderResumeStatus;
 import project.forwork.api.domain.orderresume.model.OrderResume;
 import project.forwork.api.domain.orderresume.service.port.OrderResumeRepository;
@@ -69,6 +71,16 @@ public class OrderResumeService {
         orderResumeRepository.saveAll(orderResumes);
 
         return orderResumes;
+    }
+
+    public List<OrderResumeResponse> getOrderResumeList(CurrentUser currentUser){
+        List<OrderResumeStatus> statuses = List.of(OrderResumeStatus.ORDER, OrderResumeStatus.CONFIRM, OrderResumeStatus.SENT);
+        return orderResumeRepository.findByUserIdAndStatus(currentUser.getId(), statuses);
+    }
+
+    public List<OrderResumeResponse> getCanceledOrderResumeList(CurrentUser currentUser){
+        List<OrderResumeStatus> statuses = List.of(OrderResumeStatus.CANCEL);
+        return orderResumeRepository.findByUserIdAndStatus(currentUser.getId(), statuses);
     }
 
     public OrderResume getByIdWithThrow(Long orderResumeId){

--- a/src/main/java/project/forwork/api/domain/orderresume/service/OrderResumeService.java
+++ b/src/main/java/project/forwork/api/domain/orderresume/service/OrderResumeService.java
@@ -8,6 +8,7 @@ import project.forwork.api.common.domain.CurrentUser;
 import project.forwork.api.domain.cartresume.model.CartResume;
 import project.forwork.api.domain.order.model.Order;
 import project.forwork.api.domain.orderresume.controller.model.OrderResumeResponse;
+import project.forwork.api.domain.orderresume.infrastructure.OrderResumeQueryDslRepository;
 import project.forwork.api.domain.orderresume.infrastructure.enums.OrderResumeStatus;
 import project.forwork.api.domain.orderresume.model.OrderResume;
 import project.forwork.api.domain.orderresume.service.port.OrderResumeRepository;
@@ -22,6 +23,7 @@ public class OrderResumeService {
 
     private final OrderResumeRepository orderResumeRepository;
     private final SendPurchaseResumeService sendPurchaseResumeService;
+    private final OrderResumeQueryDslRepository orderResumeQueryDslRepository;
 
     public void registerByCartResume(Order order, List<CartResume> cartResumes){
         List<OrderResume> orderResumes = cartResumes.stream()
@@ -75,12 +77,12 @@ public class OrderResumeService {
 
     public List<OrderResumeResponse> getOrderResumeList(CurrentUser currentUser){
         List<OrderResumeStatus> statuses = List.of(OrderResumeStatus.ORDER, OrderResumeStatus.CONFIRM, OrderResumeStatus.SENT);
-        return orderResumeRepository.findByUserIdAndStatus(currentUser.getId(), statuses);
+        return orderResumeQueryDslRepository.findByUserIdAndStatus(currentUser.getId(), statuses);
     }
 
     public List<OrderResumeResponse> getCanceledOrderResumeList(CurrentUser currentUser){
         List<OrderResumeStatus> statuses = List.of(OrderResumeStatus.CANCEL);
-        return orderResumeRepository.findByUserIdAndStatus(currentUser.getId(), statuses);
+        return orderResumeQueryDslRepository.findByUserIdAndStatus(currentUser.getId(), statuses);
     }
 
     public OrderResume getByIdWithThrow(Long orderResumeId){

--- a/src/main/java/project/forwork/api/domain/orderresume/service/SendPurchaseResumeService.java
+++ b/src/main/java/project/forwork/api/domain/orderresume/service/SendPurchaseResumeService.java
@@ -6,6 +6,7 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import project.forwork.api.common.service.port.MailSender;
+import project.forwork.api.domain.orderresume.infrastructure.OrderResumeQueryDslRepository;
 import project.forwork.api.domain.orderresume.model.PurchaseInfo;
 import project.forwork.api.domain.orderresume.service.port.OrderResumeRepository;
 
@@ -16,11 +17,11 @@ import java.util.List;
 @RequiredArgsConstructor
 public class SendPurchaseResumeService {
 
-    private final OrderResumeRepository orderResumeRepository;
+    private final OrderResumeQueryDslRepository orderResumeQueryDslRepository;
     private final MailSender mailSender;
 
     public void sendPurchaseResume(){
-        Page<PurchaseInfo> purchaseResumePage = orderResumeRepository.findPurchaseResume();
+        Page<PurchaseInfo> purchaseResumePage = orderResumeQueryDslRepository.findPurchaseResume();
         List<PurchaseInfo> purchaseInfos = purchaseResumePage.getContent();
 
         purchaseInfos.forEach(this::sendEmail);

--- a/src/main/java/project/forwork/api/domain/orderresume/service/SendPurchaseResumeService.java
+++ b/src/main/java/project/forwork/api/domain/orderresume/service/SendPurchaseResumeService.java
@@ -2,6 +2,7 @@ package project.forwork.api.domain.orderresume.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import project.forwork.api.common.service.port.MailSender;
@@ -19,14 +20,14 @@ public class SendPurchaseResumeService {
     private final MailSender mailSender;
 
     public void sendPurchaseResume(){
-        Page<PurchaseInfo> purchaseResumePage = orderResumeRepository.getPurchaseResume();
+        Page<PurchaseInfo> purchaseResumePage = orderResumeRepository.findPurchaseResume();
         List<PurchaseInfo> purchaseInfos = purchaseResumePage.getContent();
 
         purchaseInfos.forEach(this::sendEmail);
     }
 
-
-    private void sendEmail(PurchaseInfo purchaseInfo){
+    @Async
+    public void sendEmail(PurchaseInfo purchaseInfo){
         String title = "for-work 구매 이력서 : " + purchaseInfo.getSalePostTitle();
         String content = "주문 번호 #" + purchaseInfo.getOrderId() +" <URL> : "+ purchaseInfo.getResumeUrl();
         mailSender.send(purchaseInfo.getEmail(), title, content);

--- a/src/main/java/project/forwork/api/domain/orderresume/service/port/OrderResumeRepository.java
+++ b/src/main/java/project/forwork/api/domain/orderresume/service/port/OrderResumeRepository.java
@@ -2,6 +2,7 @@ package project.forwork.api.domain.orderresume.service.port;
 
 import org.springframework.data.domain.Page;
 import project.forwork.api.domain.order.model.Order;
+import project.forwork.api.domain.orderresume.controller.model.OrderResumeResponse;
 import project.forwork.api.domain.orderresume.infrastructure.enums.OrderResumeStatus;
 import project.forwork.api.domain.orderresume.model.OrderResume;
 import project.forwork.api.domain.orderresume.model.PurchaseInfo;
@@ -15,7 +16,9 @@ public interface OrderResumeRepository {
     OrderResume getByIdWithThrow(long orderResumeId);
     Optional<OrderResume> findById(long orderResumeId);
     List<OrderResume> findByIds(List<Long> orderResumeIds);
+    List<OrderResumeResponse> findByOrderId(Long orderId);
     List<OrderResume> findByStatusAndOrder(OrderResumeStatus status, Order order);
     List<OrderResume> findByStatusAndOrders(OrderResumeStatus status, List<Order> orders);
-    Page<PurchaseInfo> getPurchaseResume();
+    List<OrderResumeResponse> findByUserIdAndStatus(Long userId, List<OrderResumeStatus> statuses);
+    Page<PurchaseInfo> findPurchaseResume();
 }

--- a/src/main/java/project/forwork/api/domain/orderresume/service/port/OrderResumeRepository.java
+++ b/src/main/java/project/forwork/api/domain/orderresume/service/port/OrderResumeRepository.java
@@ -16,9 +16,6 @@ public interface OrderResumeRepository {
     OrderResume getByIdWithThrow(long orderResumeId);
     Optional<OrderResume> findById(long orderResumeId);
     List<OrderResume> findByIds(List<Long> orderResumeIds);
-    List<OrderResumeResponse> findByOrderId(Long orderId);
     List<OrderResume> findByStatusAndOrder(OrderResumeStatus status, Order order);
     List<OrderResume> findByStatusAndOrders(OrderResumeStatus status, List<Order> orders);
-    List<OrderResumeResponse> findByUserIdAndStatus(Long userId, List<OrderResumeStatus> statuses);
-    Page<PurchaseInfo> findPurchaseResume();
 }

--- a/src/main/java/project/forwork/api/domain/resume/infrastructure/ResumeRepositoryImpl.java
+++ b/src/main/java/project/forwork/api/domain/resume/infrastructure/ResumeRepositoryImpl.java
@@ -20,7 +20,6 @@ import java.util.Optional;
 public class ResumeRepositoryImpl implements ResumeRepository {
 
     private final ResumeJpaRepository resumeJpaRepository;
-    private final ResumeQueryDlsRepository resumeQueryDlsRepository;
 
 
     @Override
@@ -31,12 +30,6 @@ public class ResumeRepositoryImpl implements ResumeRepository {
     @Override
     public void delete(Resume resume) {
         resumeJpaRepository.delete(ResumeEntity.from(resume));
-    }
-
-    @Override
-    public void deleteAllBySeller(User seller) {
-        List<ResumeEntity> resumeEntities = resumeJpaRepository.findAllBySellerEntity(UserEntity.from(seller));
-        resumeJpaRepository.deleteAll(resumeEntities);
     }
 
     @Override
@@ -73,10 +66,5 @@ public class ResumeRepositoryImpl implements ResumeRepository {
                 .stream()
                 .map(ResumeEntity::toModel)
                 .toList();
-    }
-
-    @Override
-    public Page<ResumeResponse> search(ResumeSearchCond cond, PageRequest pageRequest) {
-        return resumeQueryDlsRepository.search(cond, pageRequest);
     }
 }

--- a/src/main/java/project/forwork/api/domain/resume/model/Resume.java
+++ b/src/main/java/project/forwork/api/domain/resume/model/Resume.java
@@ -86,9 +86,8 @@ public class Resume {
     }
 
     public String createSalePostTitle(){
-        return level.getDescription() + " : " + field.getDescription() + " 이력서 #" + getId();
+        return level.getDescription() + " " + field.getDescription() + " 이력서 #" + getId();
     }
-
 
     public boolean isAuthorMismatch(Long sellerId){
         log.info("sellerId={}, sellerId={}",seller.getId(), sellerId);

--- a/src/main/java/project/forwork/api/domain/resume/service/ResumeService.java
+++ b/src/main/java/project/forwork/api/domain/resume/service/ResumeService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import project.forwork.api.common.error.ResumeErrorCode;
 import project.forwork.api.common.exception.ApiException;
 import project.forwork.api.domain.resume.controller.model.*;
+import project.forwork.api.domain.resume.infrastructure.ResumeQueryDlsRepository;
 import project.forwork.api.domain.resume.infrastructure.enums.ResumeStatus;
 import project.forwork.api.domain.resume.model.Resume;
 import project.forwork.api.domain.resume.service.port.ResumeRepository;
@@ -27,6 +28,7 @@ public class ResumeService {
 
     private final ResumeRepository resumeRepository;
     private final ResumeDecisionRepository resumeDecisionRepository;
+    private final ResumeQueryDlsRepository resumeQueryDlsRepository;
     private final UserRepository userRepository;
 
     public Resume register(CurrentUser currentUser, ResumeRegisterRequest body){
@@ -101,7 +103,7 @@ public class ResumeService {
     ){
         Sort sort = Sort.by(ascending ? Sort.Order.asc(sortBy) : Sort.Order.desc(sortBy));
         PageRequest pageRequest = PageRequest.of(offset, limit, sort);
-        Page<ResumeResponse> result = resumeRepository.search(cond, pageRequest);
+        Page<ResumeResponse> result = resumeQueryDlsRepository.search(cond, pageRequest);
         return ResumePage.from(result);
     }
 

--- a/src/main/java/project/forwork/api/domain/resume/service/port/ResumeRepository.java
+++ b/src/main/java/project/forwork/api/domain/resume/service/port/ResumeRepository.java
@@ -17,8 +17,6 @@ public interface ResumeRepository {
 
     void delete(Resume resume);
 
-    void deleteAllBySeller(User Seller);
-
     Resume getByIdWithThrow(Long id);
 
     Optional<Resume> findById(Long id);
@@ -28,6 +26,4 @@ public interface ResumeRepository {
     List<Resume> findAllByStatus(ResumeStatus status);
 
     List<Resume> findAllBySeller(User seller);
-
-    Page<ResumeResponse> search(ResumeSearchCond cond, PageRequest pageRequest);
 }

--- a/src/main/java/project/forwork/api/domain/salepost/infrastructure/SalePostQueryDslRepository.java
+++ b/src/main/java/project/forwork/api/domain/salepost/infrastructure/SalePostQueryDslRepository.java
@@ -35,7 +35,7 @@ public class SalePostQueryDslRepository {
         this.queryFactory  = new JPAQueryFactory(em);
     }
 
-    public Page<SalePostResponse> search(SalePostSearchCond cond, Pageable pageable, SalePostSortType sortType){
+    public Page<SalePostResponse> searchByCondition(SalePostSearchCond cond, Pageable pageable, SalePostSortType sortType){
 
         OrderSpecifier orderSpecifier = createOrderSpecifier(sortType);
 

--- a/src/main/java/project/forwork/api/domain/salepost/infrastructure/SalePostRepositoryImpl.java
+++ b/src/main/java/project/forwork/api/domain/salepost/infrastructure/SalePostRepositoryImpl.java
@@ -22,7 +22,7 @@ import java.util.Optional;
 public class SalePostRepositoryImpl implements SalePostRepository {
 
     private final SalePostJpaRepository salePostJpaRepository;
-    private final SalePostQueryDslRepository salePostQueryDslRepository;
+
     @Override
     public SalePost save(SalePost salePost) {
         return salePostJpaRepository.save(SalePostEntity.from(salePost)).toModel();
@@ -50,10 +50,5 @@ public class SalePostRepositoryImpl implements SalePostRepository {
         return salePostJpaRepository.findByResumeEntity(ResumeEntity.from(resume))
                 .orElseThrow(() -> new ApiException(SalePostErrorCode.SALE_POST_NOT_FOUND))
                 .toModel();
-    }
-
-    @Override
-    public Page<SalePostResponse> searchByCondition(SalePostSearchCond cond, PageRequest pageRequest, SalePostSortType sortType) {
-        return salePostQueryDslRepository.search(cond, pageRequest, sortType);
     }
 }

--- a/src/main/java/project/forwork/api/domain/salepost/service/SalePostService.java
+++ b/src/main/java/project/forwork/api/domain/salepost/service/SalePostService.java
@@ -10,6 +10,7 @@ import project.forwork.api.common.domain.CurrentUser;
 import project.forwork.api.domain.resume.model.Resume;
 import project.forwork.api.domain.salepost.controller.model.SalePostPage;
 import project.forwork.api.domain.salepost.controller.model.SalePostResponse;
+import project.forwork.api.domain.salepost.infrastructure.SalePostQueryDslRepository;
 import project.forwork.api.domain.salepost.infrastructure.enums.SalesStatus;
 import project.forwork.api.domain.salepost.infrastructure.SalePostSearchCond;
 import project.forwork.api.domain.salepost.infrastructure.enums.SalePostSortType;
@@ -24,6 +25,7 @@ public class SalePostService {
 
     private final SellerValidationService sellerValidationService;
     private final SalePostRepository salePostRepository;
+    private final SalePostQueryDslRepository salePostQueryDslRepository;
 
     public SalePost register(CurrentUser currentUser, Long resumeId){
         Resume resume = sellerValidationService.validateSellerAndResumeStatus(currentUser, resumeId);
@@ -67,7 +69,7 @@ public class SalePostService {
             SalePostSearchCond cond
     ){
         PageRequest pageRequest = PageRequest.of(offset, limit);
-        Page<SalePostResponse> result = salePostRepository.searchByCondition(cond, pageRequest, sortType);
+        Page<SalePostResponse> result = salePostQueryDslRepository.searchByCondition(cond, pageRequest, sortType);
         return SalePostPage.from(result);
     }
 }

--- a/src/main/java/project/forwork/api/domain/salepost/service/port/SalePostRepository.java
+++ b/src/main/java/project/forwork/api/domain/salepost/service/port/SalePostRepository.java
@@ -21,6 +21,4 @@ public interface SalePostRepository {
     SalePost getSellingPostWithThrow(Long resumeId);
 
     SalePost getByResumeWithThrow(Resume resume);
-
-    Page<SalePostResponse> searchByCondition(SalePostSearchCond cond, PageRequest pageRequest, SalePostSortType sortType);
 }

--- a/src/test/java/project/forwork/api/domain/orderresume/infrastructure/OrderResumeQueryDslRepositoryTest.java
+++ b/src/test/java/project/forwork/api/domain/orderresume/infrastructure/OrderResumeQueryDslRepositoryTest.java
@@ -1,0 +1,73 @@
+package project.forwork.api.domain.orderresume.infrastructure;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.SqlGroup;
+import project.forwork.api.domain.orderresume.controller.model.OrderResumeResponse;
+import project.forwork.api.domain.orderresume.infrastructure.enums.OrderResumeStatus;
+import project.forwork.api.domain.orderresume.model.PurchaseInfo;
+
+import java.util.List;
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+@SpringBootTest
+@TestPropertySource("classpath:test-application.yml")
+@SqlGroup({
+        @Sql(value = "/sql/user-test-data.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD),
+        @Sql(value = "/sql/resume-test-data.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD),
+        @Sql(value = "/sql/order-test-data.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD),
+        @Sql(value = "/sql/order-resume-test-data.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD),
+        @Sql(value = "/sql/delete-all-data.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
+})
+class OrderResumeQueryDslRepositoryTest {
+
+    @Autowired
+    private OrderResumeQueryDslRepository orderResumeQueryDslRepository;
+
+    @Test
+    void findPurchaseResume_메서드는_CONFIRM_상태인_OrderResume_들로_PurchaseInfo_들을_반환_한다(){
+        //given(상황환경 세팅)
+
+        //when(상황발생)
+        Page<PurchaseInfo> purchaseResume = orderResumeQueryDslRepository.findPurchaseResume();
+        List<PurchaseInfo> content = purchaseResume.getContent();
+
+        //then(검증)
+        assertThat(content.size()).isEqualTo(2);
+    }
+
+    @Test
+    void findByUserIdAndStatus_메서드는_USER_ID와_OrderOrderResumeStatus_들로_OrderResumeResponse_들을_반환_한다(){
+        //given(상황환경 세팅)
+        List<OrderResumeStatus> statuses = List.of(OrderResumeStatus.ORDER, OrderResumeStatus.CONFIRM, OrderResumeStatus.SENT);
+
+        //when(상황발생)
+        List<OrderResumeResponse> orderResumeResponses = orderResumeQueryDslRepository.findByUserIdAndStatus(1L, statuses);
+
+        //then(검증)
+        assertThat(orderResumeResponses).isNotEmpty();
+
+        for (OrderResumeResponse response : orderResumeResponses) {
+            assertThat(statuses).contains(response.getStatus());
+        }
+    }
+
+    @Test
+    void findByOrderId_메서드는_ORDER_ID_로_ORDER_에_속한_모든_OrderResumeResponse_을_반환_한다(){
+        //given(상황환경 세팅)
+        //when(상황발생)
+        List<OrderResumeResponse> orderResumeResponses = orderResumeQueryDslRepository.findByOrderId(8L);
+
+        //then(검증)
+        assertThat(orderResumeResponses).isNotEmpty();
+        assertThat(orderResumeResponses.size()).isEqualTo(2);
+        assertThat(orderResumeResponses).allMatch(or -> Objects.equals(or.getOrderId(), 8L));
+        assertThat(orderResumeResponses.get(0).getTitle()).isEqualTo("NEW BACKEND 이력서 #4");
+    }
+}

--- a/src/test/java/project/forwork/api/domain/orderresume/service/OrderResumeServiceTest.java
+++ b/src/test/java/project/forwork/api/domain/orderresume/service/OrderResumeServiceTest.java
@@ -5,8 +5,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.SqlGroup;
 import project.forwork.api.domain.cartresume.model.CartResume;
 import project.forwork.api.domain.order.model.Order;
+import project.forwork.api.domain.orderresume.infrastructure.OrderResumeQueryDslRepository;
 import project.forwork.api.domain.orderresume.infrastructure.enums.OrderResumeStatus;
 import project.forwork.api.domain.orderresume.model.OrderResume;
 import project.forwork.api.domain.resume.infrastructure.enums.FieldType;
@@ -25,8 +31,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.jupiter.api.Assertions.*;
 
+@SpringBootTest
+@TestPropertySource("classpath:test-application.yml")
+@SqlGroup({
+        @Sql(value = "/sql/user-test-data.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD),
+        @Sql(value = "/sql/resume-test-data.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD),
+        @Sql(value = "/sql/order-test-data.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD),
+        @Sql(value = "/sql/order-resume-test-data.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD),
+        @Sql(value = "/sql/delete-all-data.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
+})
 class OrderResumeServiceTest {
 
+    @Autowired
+    private OrderResumeQueryDslRepository orderResumeQueryDslRepository;
     private OrderResumeService orderResumeService;
 
     @BeforeEach
@@ -35,7 +52,7 @@ class OrderResumeServiceTest {
         FakeMailSender fakeMailSender = new FakeMailSender();
         this.orderResumeService = OrderResumeService.builder()
                 .orderResumeRepository(fakeOrderResumeRepository)
-                .sendPurchaseResumeService(new SendPurchaseResumeService(fakeOrderResumeRepository, fakeMailSender))
+                .sendPurchaseResumeService(new SendPurchaseResumeService(orderResumeQueryDslRepository, fakeMailSender))
                 .build();
 
         User user1 = User.builder()

--- a/src/test/java/project/forwork/api/domain/orderresume/service/SendPurchaseResumeServiceTest.java
+++ b/src/test/java/project/forwork/api/domain/orderresume/service/SendPurchaseResumeServiceTest.java
@@ -8,8 +8,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
+import project.forwork.api.domain.orderresume.infrastructure.OrderResumeQueryDslRepository;
 import project.forwork.api.domain.orderresume.model.PurchaseInfo;
-import project.forwork.api.domain.orderresume.service.port.OrderResumeRepository;
 import project.forwork.api.domain.resume.infrastructure.enums.FieldType;
 import project.forwork.api.domain.resume.infrastructure.enums.LevelType;
 import project.forwork.api.mock.FakeMailSender;
@@ -18,12 +18,11 @@ import static org.mockito.Mockito.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.List;
-
 @ExtendWith(MockitoExtension.class)
 public class SendPurchaseResumeServiceTest {
 
     @Mock
-    private OrderResumeRepository orderResumeRepository;
+    private OrderResumeQueryDslRepository orderResumeQueryDslRepository;
 
     private FakeMailSender fakeMailSender;
 
@@ -32,15 +31,16 @@ public class SendPurchaseResumeServiceTest {
     @BeforeEach
     public void init() {
         fakeMailSender = new FakeMailSender();
-        sendPurchaseResumeService = new SendPurchaseResumeService(orderResumeRepository, fakeMailSender);
+        sendPurchaseResumeService = new SendPurchaseResumeService(orderResumeQueryDslRepository, fakeMailSender);
     }
 
     @Test
     public void testSendPurchaseResume() {
+
         PageRequest pageRequest = PageRequest.of(0, 20);
         PurchaseInfo purchaseInfo = PurchaseInfo.builder()
                 .orderId(1L)
-                .resumeId(2L)
+                .resumeId(4L)
                 .email("user@naver.com")
                 .level(LevelType.NEW)
                 .field(FieldType.BACKEND)
@@ -48,12 +48,12 @@ public class SendPurchaseResumeServiceTest {
                 .build();
         Page<PurchaseInfo> purchaseInfoPage = new PageImpl<>(List.of(purchaseInfo), pageRequest, 1);
 
-        when(orderResumeRepository.findPurchaseResume()).thenReturn(purchaseInfoPage);
+        when(orderResumeQueryDslRepository.findPurchaseResume()).thenReturn(purchaseInfoPage);
 
         sendPurchaseResumeService.sendPurchaseResume();
 
         assertEquals("user@naver.com", fakeMailSender.email);
-        assertEquals("for-work 구매 이력서 : 신입 백엔드 이력서 #2", fakeMailSender.title);
+        assertEquals("for-work 구매 이력서 : 신입 백엔드 이력서 #4", fakeMailSender.title);
         assertEquals("주문 번호 #1 <URL> : www.test.com", fakeMailSender.content);
     }
 }

--- a/src/test/java/project/forwork/api/domain/orderresume/service/SendPurchaseResumeServiceTest.java
+++ b/src/test/java/project/forwork/api/domain/orderresume/service/SendPurchaseResumeServiceTest.java
@@ -3,7 +3,6 @@ package project.forwork.api.domain.orderresume.service;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
@@ -49,7 +48,7 @@ public class SendPurchaseResumeServiceTest {
                 .build();
         Page<PurchaseInfo> purchaseInfoPage = new PageImpl<>(List.of(purchaseInfo), pageRequest, 1);
 
-        when(orderResumeRepository.getPurchaseResume()).thenReturn(purchaseInfoPage);
+        when(orderResumeRepository.findPurchaseResume()).thenReturn(purchaseInfoPage);
 
         sendPurchaseResumeService.sendPurchaseResume();
 

--- a/src/test/java/project/forwork/api/domain/resume/infrastructure/ResumeQueryDlsRepositoryTest.java
+++ b/src/test/java/project/forwork/api/domain/resume/infrastructure/ResumeQueryDlsRepositoryTest.java
@@ -1,4 +1,4 @@
-package project.forwork.api.domain.resume.infrastructure.querydsl;
+package project.forwork.api.domain.resume.infrastructure;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest
 @TestPropertySource("classpath:test-application.yml")
 @SqlGroup({
+        @Sql(value = "/sql/user-test-data.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD),
         @Sql(value = "/sql/resume-test-data.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD),
         @Sql(value = "/sql/delete-all-data.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
 })

--- a/src/test/java/project/forwork/api/domain/salepost/infrastructure/SalePostQueryDslRepositoryTest.java
+++ b/src/test/java/project/forwork/api/domain/salepost/infrastructure/SalePostQueryDslRepositoryTest.java
@@ -1,4 +1,4 @@
-package project.forwork.api.domain.salepost.infrastructure.query;
+package project.forwork.api.domain.salepost.infrastructure;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest
 @TestPropertySource("classpath:test-application.yml")
 @SqlGroup({
+        @Sql(value = "/sql/user-test-data.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD),
         @Sql(value = "/sql/resume-test-data.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD),
         @Sql(value = "/sql/sale-post-test-data.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD),
         @Sql(value = "/sql/delete-all-data.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)

--- a/src/test/java/project/forwork/api/domain/salepost/infrastructure/query/SalePostQueryDslRepositoryTest.java
+++ b/src/test/java/project/forwork/api/domain/salepost/infrastructure/query/SalePostQueryDslRepositoryTest.java
@@ -47,7 +47,7 @@ class SalePostQueryDslRepositoryTest {
 
 
         //when(상황발생)
-        Page<SalePostResponse> result = repository.search(cond, pageRequest, SalePostSortType.BEST_SELLING);
+        Page<SalePostResponse> result = repository.searchByCondition(cond, pageRequest, SalePostSortType.BEST_SELLING);
         List<SalePostResponse> content = result.getContent();
 
         //then(검증)
@@ -63,7 +63,7 @@ class SalePostQueryDslRepositoryTest {
 
 
         //when(상황발생)
-        Page<SalePostResponse> result = repository.search(cond, pageRequest, SalePostSortType.BEST_SELLING);
+        Page<SalePostResponse> result = repository.searchByCondition(cond, pageRequest, SalePostSortType.BEST_SELLING);
         List<SalePostResponse> content = result.getContent();
 
         //then(검증)
@@ -79,7 +79,7 @@ class SalePostQueryDslRepositoryTest {
         PageRequest pageRequest = PageRequest.of(0, 10);
 
         //when(상황발생)
-        Page<SalePostResponse> result = repository.search(cond, pageRequest, SalePostSortType.BEST_SELLING);
+        Page<SalePostResponse> result = repository.searchByCondition(cond, pageRequest, SalePostSortType.BEST_SELLING);
         List<SalePostResponse> content = result.getContent();
 
         //then(검증)
@@ -95,7 +95,7 @@ class SalePostQueryDslRepositoryTest {
         PageRequest pageRequest = PageRequest.of(0, 10);
 
         //when(상황발생)
-        Page<SalePostResponse> result = repository.search(cond, pageRequest, SalePostSortType.BEST_SELLING);
+        Page<SalePostResponse> result = repository.searchByCondition(cond, pageRequest, SalePostSortType.BEST_SELLING);
         List<SalePostResponse> content = result.getContent();
 
         //then(검증)
@@ -112,7 +112,7 @@ class SalePostQueryDslRepositoryTest {
         PageRequest pageRequest = PageRequest.of(0, 10);
 
         //when(상황발생)
-        Page<SalePostResponse> result = repository.search(cond, pageRequest, SalePostSortType.BEST_SELLING);
+        Page<SalePostResponse> result = repository.searchByCondition(cond, pageRequest, SalePostSortType.BEST_SELLING);
         List<SalePostResponse> content = result.getContent();
 
         //then(검증)
@@ -130,7 +130,7 @@ class SalePostQueryDslRepositoryTest {
         PageRequest pageRequest = PageRequest.of(0, 10);
 
         //when(상황발생)
-        Page<SalePostResponse> result = repository.search(cond, pageRequest, SalePostSortType.BEST_SELLING);
+        Page<SalePostResponse> result = repository.searchByCondition(cond, pageRequest, SalePostSortType.BEST_SELLING);
         List<SalePostResponse> content = result.getContent();
 
         //then(검증)
@@ -148,7 +148,7 @@ class SalePostQueryDslRepositoryTest {
         PageRequest pageRequest = PageRequest.of(0, 10);
 
         //when(상황발생)
-        Page<SalePostResponse> result = repository.search(cond, pageRequest, SalePostSortType.BEST_SELLING);
+        Page<SalePostResponse> result = repository.searchByCondition(cond, pageRequest, SalePostSortType.BEST_SELLING);
         List<SalePostResponse> content = result.getContent();
 
         //then(검증)
@@ -164,7 +164,7 @@ class SalePostQueryDslRepositoryTest {
         PageRequest pageRequest = PageRequest.of(0, 10);
 
         //when(상황발생)
-        Page<SalePostResponse> result = repository.search(cond, pageRequest, SalePostSortType.BEST_SELLING);
+        Page<SalePostResponse> result = repository.searchByCondition(cond, pageRequest, SalePostSortType.BEST_SELLING);
         List<SalePostResponse> content = result.getContent();
 
         //then(검증)
@@ -182,7 +182,7 @@ class SalePostQueryDslRepositoryTest {
         PageRequest pageRequest = PageRequest.of(0, 10);
 
         //when(상황발생)
-        Page<SalePostResponse> result = repository.search(cond, pageRequest, SalePostSortType.BEST_SELLING);
+        Page<SalePostResponse> result = repository.searchByCondition(cond, pageRequest, SalePostSortType.BEST_SELLING);
         List<SalePostResponse> content = result.getContent();
 
         //then(검증)
@@ -204,7 +204,7 @@ class SalePostQueryDslRepositoryTest {
         PageRequest pageRequest = PageRequest.of(0, 10);
 
         //when(상황발생)
-        Page<SalePostResponse> result = repository.search(cond, pageRequest, SalePostSortType.BEST_SELLING);
+        Page<SalePostResponse> result = repository.searchByCondition(cond, pageRequest, SalePostSortType.BEST_SELLING);
         List<SalePostResponse> content = result.getContent();
 
         //then(검증)

--- a/src/test/java/project/forwork/api/mock/FakeOrderRepository.java
+++ b/src/test/java/project/forwork/api/mock/FakeOrderRepository.java
@@ -53,17 +53,26 @@ public class FakeOrderRepository implements OrderRepository {
     }
 
     @Override
-    public Order getByIdWithThrow(long id) {
-        return findById(id).orElseThrow(() -> new ApiException(OrderErrorCode.ORDER_NOT_FOUND, id));
+    public Order getByIdWithThrow(Long orderId) {
+        return findById(orderId).orElseThrow(() -> new ApiException(OrderErrorCode.ORDER_NOT_FOUND, orderId));
     }
 
     @Override
-    public Optional<Order> findById(long id) {
-        return data.stream().filter(o -> Objects.equals(o.getId(), id)).findAny();
+    public Order getOrderWithThrow(Long userId, Long orderId) {
+        return data.stream()
+                .filter(o -> Objects.equals(o.getId(), orderId) &&
+                Objects.equals(o.getUser().getId(), userId))
+                .findAny()
+                .orElseThrow(() -> new ApiException(OrderErrorCode.ORDER_NOT_FOUND, orderId));
     }
 
     @Override
-    public List<Order> findAllByStatus(OrderStatus status) {
+    public Optional<Order> findById(Long orderId) {
+        return data.stream().filter(o -> Objects.equals(o.getId(), orderId)).findAny();
+    }
+
+    @Override
+    public List<Order> findByStatus(OrderStatus status) {
         return data.stream().filter(order -> Objects.equals(order.getStatus(), status)).toList();
     }
 }

--- a/src/test/java/project/forwork/api/mock/FakeOrderResumeRepository.java
+++ b/src/test/java/project/forwork/api/mock/FakeOrderResumeRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Pageable;
 import project.forwork.api.common.error.OrderResumeErrorCode;
 import project.forwork.api.common.exception.ApiException;
 import project.forwork.api.domain.order.model.Order;
+import project.forwork.api.domain.orderresume.controller.model.OrderResumeResponse;
 import project.forwork.api.domain.orderresume.infrastructure.enums.OrderResumeStatus;
 import project.forwork.api.domain.orderresume.model.OrderResume;
 import project.forwork.api.domain.orderresume.model.PurchaseInfo;
@@ -24,9 +25,6 @@ public class FakeOrderResumeRepository implements OrderResumeRepository {
 
     private final AtomicLong id = new AtomicLong(0);
     private final List<OrderResume> data = new ArrayList<>();
-
-
-
 
     @Override
     public OrderResume save(OrderResume orderResume) {
@@ -85,20 +83,5 @@ public class FakeOrderResumeRepository implements OrderResumeRepository {
                 .filter(orderResume -> orderIds.contains(orderResume.getOrder().getId()) &&
                         Objects.equals(orderResume.getStatus(), OrderResumeStatus.ORDER))
                 .toList();
-    }
-
-    @Override
-    public Page<PurchaseInfo> getPurchaseResume() {
-        PurchaseInfo purchaseInfo = PurchaseInfo.builder()
-                .orderId(10L)
-                .resumeId(20L)
-                .email("user@naver.com")
-                .level(LevelType.NEW)
-                .field(FieldType.BACKEND)
-                .resumeUrl("www.test.com")
-                .build();
-
-        Pageable pageable = PageRequest.of(0, 20);
-        return new PageImpl<>(List.of(purchaseInfo), pageable, 1);
     }
 }

--- a/src/test/java/project/forwork/api/mock/FakeResumeRepository.java
+++ b/src/test/java/project/forwork/api/mock/FakeResumeRepository.java
@@ -52,11 +52,6 @@ public class FakeResumeRepository implements ResumeRepository {
     }
 
     @Override
-    public void deleteAllBySeller(User Seller) {
-        //
-    }
-
-    @Override
     public Resume getByIdWithThrow(Long id) {
         return findById(id).orElseThrow(() -> new ApiException(ResumeErrorCode.RESUME_NOT_FOUND, id));
     }
@@ -79,10 +74,5 @@ public class FakeResumeRepository implements ResumeRepository {
     @Override
     public List<Resume> findAllBySeller(User seller) {
         return data.stream().filter(r -> Objects.equals(r.getSeller(), seller)).toList();
-    }
-
-    @Override
-    public Page<ResumeResponse> search(ResumeSearchCond cond, PageRequest pageRequest) {
-        return null; //querydsl
     }
 }

--- a/src/test/java/project/forwork/api/mock/FakeSalePostRepository.java
+++ b/src/test/java/project/forwork/api/mock/FakeSalePostRepository.java
@@ -74,9 +74,4 @@ public class FakeSalePostRepository implements SalePostRepository {
                 .findAny()
                 .orElseThrow(() -> new ApiException(SalePostErrorCode.SALE_POST_NOT_FOUND));
     }
-
-    @Override
-    public Page<SalePostResponse> searchByCondition(SalePostSearchCond cond, PageRequest pageRequest, SalePostSortType sortType) {
-        return null;
-    }
 }

--- a/src/test/resources/sql/delete-all-data.sql
+++ b/src/test/resources/sql/delete-all-data.sql
@@ -1,4 +1,7 @@
 DELETE FROM resume_decisions;
+DELETE FROM order_resumes;
+DELETE FROM orders;
 DELETE FROM sale_posts;
 DELETE FROM resumes;
+DELETE FROM users;
 

--- a/src/test/resources/sql/order-resume-test-data.sql
+++ b/src/test/resources/sql/order-resume-test-data.sql
@@ -1,0 +1,15 @@
+INSERT INTO `order_resumes` (`order_id`, `order_resume_id`, `resume_id`, `status`) VALUES ('1', '1', '4', 'ORDER');
+INSERT INTO `order_resumes` (`order_id`, `order_resume_id`, `resume_id`, `status`) VALUES ('2', '2', '6', 'ORDER');
+INSERT INTO `order_resumes` (`order_id`, `order_resume_id`, `resume_id`, `status`) VALUES ('2', '3', '7', 'CANCEL');
+INSERT INTO `order_resumes` (`order_id`, `order_resume_id`, `resume_id`, `status`) VALUES ('3', '4', '7', 'SENT');
+INSERT INTO `order_resumes` (`order_id`, `order_resume_id`, `resume_id`, `status`) VALUES ('3', '5', '8', 'SENT');
+INSERT INTO `order_resumes` (`order_id`, `order_resume_id`, `resume_id`, `status`) VALUES ('4', '6', '5', 'CONFIRM');
+INSERT INTO `order_resumes` (`order_id`, `order_resume_id`, `resume_id`, `status`) VALUES ('5', '7', '7', 'CONFIRM');
+INSERT INTO `order_resumes` (`order_id`, `order_resume_id`, `resume_id`, `status`) VALUES ('5', '8', '5', 'CANCEL');
+INSERT INTO `order_resumes` (`order_id`, `order_resume_id`, `resume_id`, `status`) VALUES ('6', '9', '4', 'CANCEL');
+INSERT INTO `order_resumes` (`order_id`, `order_resume_id`, `resume_id`, `status`) VALUES ('6', '10', '7', 'CANCEL');
+INSERT INTO `order_resumes` (`order_id`, `order_resume_id`, `resume_id`, `status`) VALUES ('7', '11', '5', 'ORDER');
+INSERT INTO `order_resumes` (`order_id`, `order_resume_id`, `resume_id`, `status`) VALUES ('7', '12', '6', 'ORDER');
+INSERT INTO `order_resumes` (`order_id`, `order_resume_id`, `resume_id`, `status`) VALUES ('7', '13', '7', 'ORDER');
+INSERT INTO `order_resumes` (`order_id`, `order_resume_id`, `resume_id`, `status`) VALUES ('8', '14', '4', 'CANCEL');
+INSERT INTO `order_resumes` (`order_id`, `order_resume_id`, `resume_id`, `status`) VALUES ('8', '15', '6', 'SENT');

--- a/src/test/resources/sql/order-test-data.sql
+++ b/src/test/resources/sql/order-test-data.sql
@@ -1,0 +1,33 @@
+-- 4 : 70000 , 5 : 70000 6 : 65000 , 7 : 30000, 8 : 99000
+
+-- 4 결제완료
+INSERT INTO `orders` (`ordered_at`, `order_id`, `user_id`, `status`, `total_price`)
+VALUES ('2024-09-04 00:18:39', '1', '1', 'ORDER', '70000');
+
+-- 6결제완료 7 부분취소
+INSERT INTO `orders` (`canceled_at`, `ordered_at`, `order_id`, `user_id`, `status`, `total_price`)
+VALUES ('2024-09-09 08:28:39', '2024-09-09 08:18:39', '2', '2', 'PARTIAL_CANCEL', '65000');
+
+-- 7, 8 구매확정
+INSERT INTO `orders` (`confirmed_at`, `ordered_at`, `order_id`, `user_id`, `status`, `total_price`)
+VALUES ('2024-09-05 14:55:39', '2024-09-05 15:20:39', '3', '3', 'CONFIRM', '129000');
+
+-- 5 발송대기
+INSERT INTO `orders` (`ordered_at`, `order_id`, `user_id`, `status`, `total_price`)
+VALUES ('2024-08-14 18:18:39', '4', '4', 'WAIT', '70000');
+
+-- 7 발송대기 5 취소
+INSERT INTO `orders` (`canceled_at`, `ordered_at`, `order_id`, `user_id`, `status`, `total_price`)
+VALUES ('2024-09-11 09:23:39', '2024-09-11 09:18:39', '5', '1', 'PARTIAL_WAIT', '30000');
+
+-- 전체 취소
+INSERT INTO `orders` (`canceled_at`, `ordered_at`, `order_id`, `user_id`, `status`, `total_price`)
+VALUES ('2024-09-05 00:21:39', '2024-09-05 00:18:39', '6', '1', 'CANCEL', '0');
+
+-- 5,6,7 결제완료
+INSERT INTO `orders` (`ordered_at`, `order_id`, `user_id`, `status`, `total_price`)
+VALUES ('2024-09-04 00:18:39', '7', '2', 'ORDER', '165000');
+
+-- 4 취소 6 부분구매확정
+INSERT INTO `orders` (`confirmed_at`, `canceled_at`, `ordered_at`, `order_id`, `user_id`, `status`, `total_price`)
+VALUES ('2024-09-09 08:38:39', '2024-09-09 08:28:39', '2024-09-09 08:18:39', '8', '3', 'PARTIAL_CONFIRM', '65000');

--- a/src/test/resources/sql/user-test-data.sql
+++ b/src/test/resources/sql/user-test-data.sql
@@ -1,0 +1,11 @@
+INSERT INTO `users` (`user_id`, `name`, `email`, `password`, `role`)
+VALUES ('1', 'user1', 'test1@naver.com', '123', 'USER');
+
+INSERT INTO `users` (`user_id`, `name`, `email`, `password`, `role`)
+VALUES ('2', 'user2', 'test2@naver.com', '234', 'USER');
+
+INSERT INTO `users` (`user_id`, `name`, `email`, `password`, `role`)
+VALUES ('3', 'user3', 'test3@naver.com', '345', 'USER');
+
+INSERT INTO `users` (`user_id`, `name`, `email`, `password`, `role`)
+VALUES ('4', 'user4', 'test4@naver.com', '456', 'USER');


### PR DESCRIPTION
- 주문 내역은 OrderResume으로 조회 가능 하고 확정, 취소 상태로 분류 하였습니다.
- 주문 상세보기시 OrderDetailResponse 을 반환하고 해당 주문에 속해있는 OrderResume을 조회 가능 합니다.
- OrderResumeService에 있는 비지니스 로직 테스트
- 구매확정시 메일을 보내는 SendPurchaseResumeService 테스트
- QueryDsl 을 활용한 조회 쿼리 메서드 테스트 (h2 인 메모리 사용)
