### PR TITLE
QueryDsl 페이징 처리 쿼리 튜닝 & 테스트 코드 작성

### DIFF
--- a/src/main/java/project/forwork/api/common/infrastructure/SystemClockHolder.java
+++ b/src/main/java/project/forwork/api/common/infrastructure/SystemClockHolder.java
@@ -3,6 +3,7 @@ package project.forwork.api.common.infrastructure;
 import org.springframework.stereotype.Component;
 import project.forwork.api.common.service.port.ClockHolder;
 import java.time.Clock;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Date;
@@ -23,5 +24,9 @@ public class SystemClockHolder implements ClockHolder {
 
     public LocalDateTime now() {
         return LocalDateTime.now();
+    }
+
+    public LocalDate nowDate(){
+        return LocalDate.now();
     }
 }

--- a/src/main/java/project/forwork/api/common/service/port/ClockHolder.java
+++ b/src/main/java/project/forwork/api/common/service/port/ClockHolder.java
@@ -1,5 +1,6 @@
 package project.forwork.api.common.service.port;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Date;
 
@@ -7,5 +8,6 @@ public interface ClockHolder {
     long millis();
     long convertSecondsFrom(long minutes);
     LocalDateTime now();
+    LocalDate nowDate();
     Date convertExpiredDateFrom(long millis);
 }

--- a/src/main/java/project/forwork/api/domain/resume/infrastructure/ResumeQueryDlsRepository.java
+++ b/src/main/java/project/forwork/api/domain/resume/infrastructure/ResumeQueryDlsRepository.java
@@ -1,24 +1,30 @@
 package project.forwork.api.domain.resume.infrastructure;
 
+import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.ComparableExpressionBase;
 import com.querydsl.core.types.dsl.PathBuilder;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
-import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
+import lombok.Builder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
+import project.forwork.api.common.service.port.ClockHolder;
 import project.forwork.api.domain.resume.controller.model.ResumeResponse;
 import project.forwork.api.domain.resume.infrastructure.enums.FieldType;
 import project.forwork.api.domain.resume.infrastructure.enums.LevelType;
+import project.forwork.api.domain.resume.infrastructure.enums.PeriodCond;
 import project.forwork.api.domain.resume.infrastructure.enums.ResumeStatus;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
 
 import static project.forwork.api.domain.resume.infrastructure.QResumeEntity.*;
@@ -28,9 +34,11 @@ import static project.forwork.api.domain.user.infrastructure.QUserEntity.*;
 public class ResumeQueryDlsRepository {
 
     private final JPAQueryFactory queryFactory;
+    private final ClockHolder clockHolder;
     @Autowired
-    public ResumeQueryDlsRepository(EntityManager em) {
+    public ResumeQueryDlsRepository(EntityManager em, ClockHolder clockHolder) {
         this.queryFactory = new JPAQueryFactory(em);
+        this.clockHolder = clockHolder;
     }
 
     public Page<ResumeResponse> search(ResumeSearchCond cond, Pageable pageable) {
@@ -52,18 +60,125 @@ public class ResumeQueryDlsRepository {
                 .limit(pageable.getPageSize())
                 .fetch();
 
-        JPAQuery<Long> count = queryFactory
-                .select(resumeEntity.count())
-                .from(resumeEntity)
-                .leftJoin(resumeEntity.sellerEntity, userEntity)
-                .where(resumeStatusEqual(cond.getResumeStatus()),
-                        fieldEqual(cond.getField()),
-                        levelEqual(cond.getLevel())
-                );
+        return new PageImpl<>(content, pageable, pageable.isPaged() ? content.size() : 0);
+    }
 
-        // 전체 카운트 쿼리 없이 Page 객체 생성 TODO
-        //return new PageImpl<>(content, pageable, pageable.isPaged() ? content.size() : 0);
-        return PageableExecutionUtils.getPage(content, pageable, count::fetchOne);
+    public List<ResumeResponse> findFirstPage(ResumeSearchCond cond, int limit) {
+        return  queryFactory
+                .select(Projections.fields(ResumeResponse.class,
+                        resumeEntity.id.as("id"),
+                        resumeEntity.fieldType.as("field"),
+                        resumeEntity.levelType.as("level"),
+                        resumeEntity.resumeStatus.as("status"),
+                        resumeEntity.modifiedAt.as("modifiedAt"),
+                        userEntity.email.as("email")))
+                .from(resumeEntity)
+                .join(resumeEntity.sellerEntity, userEntity)
+                .where(dateRangeCond(cond.getPeriodCond()),
+                        resumeStatusEqual(cond.getResumeStatus())
+                )
+                .orderBy(resumeEntity.modifiedAt.asc(), resumeEntity.id.asc())
+                .limit(limit)
+                .fetch();
+    }
+
+    public List<ResumeResponse> findLastPage(ResumeSearchCond cond, int limit) {
+        List<ResumeResponse> results = queryFactory
+                .select(Projections.fields(ResumeResponse.class,
+                        resumeEntity.id.as("id"),
+                        resumeEntity.fieldType.as("field"),
+                        resumeEntity.levelType.as("level"),
+                        resumeEntity.resumeStatus.as("status"),
+                        resumeEntity.modifiedAt.as("modifiedAt"),
+                        userEntity.email.as("email")))
+                .from(resumeEntity)
+                .join(resumeEntity.sellerEntity, userEntity)
+                .where(dateRangeCond(cond.getPeriodCond()),
+                        resumeStatusEqual(cond.getResumeStatus())
+                )
+                .orderBy(resumeEntity.modifiedAt.desc(), resumeEntity.id.desc())
+                .limit(limit)
+                .fetch();
+
+        // 서버에서 데이터를 오름차순으로 정렬
+        Collections.reverse(results);
+
+        return results;
+    }
+
+    public List<ResumeResponse> findNextPage(
+            ResumeSearchCond cond, LocalDateTime lastModifiedAt,
+            Long lastId, int limit
+    ) {
+        return  queryFactory
+                .select(Projections.fields(ResumeResponse.class,
+                        resumeEntity.id.as("id"),
+                        resumeEntity.fieldType.as("field"),
+                        resumeEntity.levelType.as("level"),
+                        resumeEntity.resumeStatus.as("status"),
+                        resumeEntity.modifiedAt.as("modifiedAt"),
+                        userEntity.email.as("email")))
+                .from(resumeEntity)
+                .join(resumeEntity.sellerEntity, userEntity)
+                // TODO 필터링 조건 순서에 따른 성능 테스트 필요
+                .where(dateRangeCond(cond.getPeriodCond()),
+                        resumeStatusEqual(cond.getResumeStatus()),
+                        resumeEntity.modifiedAt.eq(lastModifiedAt)
+                                .and(resumeEntity.id.gt(lastId))
+                                .or(resumeEntity.modifiedAt.gt(lastModifiedAt))
+                )
+                .orderBy(resumeEntity.modifiedAt.asc(), resumeEntity.id.asc())
+                .limit(limit)
+                .fetch();
+    }
+
+    public List<ResumeResponse> findPreviousPage(
+            ResumeSearchCond cond, LocalDateTime firstModifiedAt,
+            Long firstId, int limit
+    ) {
+        List<ResumeResponse> results = queryFactory
+                .select(Projections.fields(ResumeResponse.class,
+                        resumeEntity.id.as("id"),
+                        resumeEntity.fieldType.as("field"),
+                        resumeEntity.levelType.as("level"),
+                        resumeEntity.resumeStatus.as("status"),
+                        resumeEntity.modifiedAt.as("modifiedAt"),
+                        userEntity.email.as("email")))
+                .from(resumeEntity)
+                .join(resumeEntity.sellerEntity, userEntity)
+                .where(dateRangeCond(cond.getPeriodCond()),
+                        resumeStatusEqual(cond.getResumeStatus()),
+                        (
+                                resumeEntity.modifiedAt.eq(firstModifiedAt)
+                                        .and(resumeEntity.id.lt(firstId))
+                        )
+                                .or(resumeEntity.modifiedAt.lt(firstModifiedAt))
+                )
+                .orderBy(resumeEntity.modifiedAt.desc(), resumeEntity.id.desc())
+                .limit(limit)
+                .fetch();
+
+        // 서버에서 데이터를 오름차순으로 정렬
+        Collections.reverse(results);
+
+        return results;
+    }
+
+    private Predicate dateRangeCond(PeriodCond cond){
+
+        if(cond == null){
+            return null;
+        }
+
+        LocalDateTime now = clockHolder.now();
+        LocalDateTime startOfToday = clockHolder.nowDate().atStartOfDay();
+
+        return switch(cond){
+            case TODAY -> resumeEntity.modifiedAt.goe(startOfToday).and(resumeEntity.modifiedAt.lt(now));
+            case WEEK -> resumeEntity.modifiedAt.goe(startOfToday.minusWeeks(1)).and(resumeEntity.modifiedAt.lt(now));
+            case MONTH -> resumeEntity.modifiedAt.goe(startOfToday.minusMonths(1)).and(resumeEntity.modifiedAt.lt(now));
+        };
+        //yield resumeEntity.modifiedAt.between(start, now); // 성능 측정 필요 TODO
     }
 
     private BooleanExpression resumeStatusEqual(ResumeStatus status) {

--- a/src/main/java/project/forwork/api/domain/resume/infrastructure/ResumeSearchCond.java
+++ b/src/main/java/project/forwork/api/domain/resume/infrastructure/ResumeSearchCond.java
@@ -3,12 +3,14 @@ package project.forwork.api.domain.resume.infrastructure;
 import lombok.Data;
 import project.forwork.api.domain.resume.infrastructure.enums.FieldType;
 import project.forwork.api.domain.resume.infrastructure.enums.LevelType;
+import project.forwork.api.domain.resume.infrastructure.enums.PeriodCond;
 import project.forwork.api.domain.resume.infrastructure.enums.ResumeStatus;
 import project.forwork.api.domain.resumedecision.infrastructure.enums.DecisionStatus;
 
 @Data // TODO 관리자가 검색하는 조건은 1일, 1주 정도로 충분 cond 필요없음
 public class ResumeSearchCond {
     private ResumeStatus resumeStatus;
+    private PeriodCond periodCond;
     private FieldType field;
     private LevelType level;
 }

--- a/src/main/java/project/forwork/api/domain/resume/infrastructure/enums/PeriodCond.java
+++ b/src/main/java/project/forwork/api/domain/resume/infrastructure/enums/PeriodCond.java
@@ -1,0 +1,24 @@
+package project.forwork.api.domain.resume.infrastructure.enums;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum PeriodCond {
+    TODAY("오늘"),
+    WEEK("1주일"),
+    MONTH("1달")
+    ;
+
+    private String description;
+
+    @JsonCreator
+    public static ResumeStatus from(String s) {
+        for (ResumeStatus status : ResumeStatus.values()) {
+            if (status.name().equalsIgnoreCase(s)) {
+                return status;
+            }
+        }
+        throw new IllegalArgumentException("Invalid ResumeStatus: " + s);
+    }
+}

--- a/src/main/java/project/forwork/api/domain/salepost/infrastructure/SalePostQueryDslRepository.java
+++ b/src/main/java/project/forwork/api/domain/salepost/infrastructure/SalePostQueryDslRepository.java
@@ -56,10 +56,12 @@ public class SalePostQueryDslRepository {
                 .from(salePostEntity)
                 .join(salePostEntity.resumeEntity, resumeEntity)
                 //.join(salePostEntity.thumbnailImageEntity, thumbnailImageEntity) // 썸네일
-                .where(salePostEntity.salesStatus.eq(SalesStatus.SELLING),
+                .where(
                         priceRangeCond(cond.getMinPrice(), cond.getMaxPrice()),
                         fieldEqual(cond.getField()),
-                        levelEqual(cond.getLevel()))
+                        levelEqual(cond.getLevel()),
+                        salePostEntity.salesStatus.eq(SalesStatus.SELLING)
+                )
                 .orderBy(orderSpecifier, salePostEntity.id.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
@@ -94,10 +96,12 @@ public class SalePostQueryDslRepository {
                 .from(salePostEntity)
                 .join(salePostEntity.resumeEntity, resumeEntity)
                 //.join(salePostEntity.thumbnailImageEntity, thumbnailImageEntity) // 썸네일
-                .where(salePostEntity.salesStatus.eq(SalesStatus.SELLING),
+                .where(
                         priceRangeCond(cond.getMinPrice(), cond.getMaxPrice()),
                         fieldEqual(cond.getField()),
-                        levelEqual(cond.getLevel()))
+                        levelEqual(cond.getLevel()),
+                        salePostEntity.salesStatus.eq(SalesStatus.SELLING)
+                )
                 .orderBy(orderSpecifier)
                 .limit(limit).fetch();
     }
@@ -123,10 +127,12 @@ public class SalePostQueryDslRepository {
                 .from(salePostEntity)
                 .join(salePostEntity.resumeEntity, resumeEntity)
                 //.join(salePostEntity.thumbnailImageEntity, thumbnailImageEntity) // 썸네일
-                .where(salePostEntity.salesStatus.eq(SalesStatus.SELLING),
+                .where(
                         priceRangeCond(cond.getMinPrice(), cond.getMaxPrice()),
                         fieldEqual(cond.getField()),
-                        levelEqual(cond.getLevel()))
+                        levelEqual(cond.getLevel()),
+                        salePostEntity.salesStatus.eq(SalesStatus.SELLING)
+                )
                 .orderBy(orderSpecifier)
                 .limit(limit).fetch();
 
@@ -155,11 +161,12 @@ public class SalePostQueryDslRepository {
                 .from(salePostEntity)
                 .join(salePostEntity.resumeEntity, resumeEntity)
                 //.join(salePostEntity.thumbnailImageEntity, thumbnailImageEntity) // 썸네일
-                .where(salePostEntity.salesStatus.eq(SalesStatus.SELLING)
-                                .and(salePostEntity.id.lt(lastId)),
+                .where(salePostEntity.id.lt(lastId).
+                                and(salePostEntity.salesStatus.eq(SalesStatus.SELLING)),
                         priceRangeCond(cond.getMinPrice(), cond.getMaxPrice()),
                         fieldEqual(cond.getField()),
-                        levelEqual(cond.getLevel()))
+                        levelEqual(cond.getLevel())
+                )
                 .orderBy(orderSpecifier)
                 .limit(limit).fetch();
     }
@@ -185,11 +192,12 @@ public class SalePostQueryDslRepository {
                 .from(salePostEntity)
                 .join(salePostEntity.resumeEntity, resumeEntity)
                 //.join(salePostEntity.thumbnailImageEntity, thumbnailImageEntity) // 썸네일
-                .where(salePostEntity.salesStatus.eq(SalesStatus.SELLING)
-                                .and(salePostEntity.id.gt(lastId)),
+                .where(salePostEntity.id.gt(lastId).
+                                and(salePostEntity.salesStatus.eq(SalesStatus.SELLING)),
                         priceRangeCond(cond.getMinPrice(), cond.getMaxPrice()),
                         fieldEqual(cond.getField()),
-                        levelEqual(cond.getLevel()))
+                        levelEqual(cond.getLevel())
+                )
                 .orderBy(orderSpecifier)
                 .limit(limit).fetch();
 

--- a/src/main/java/project/forwork/api/domain/salepost/infrastructure/SalePostQueryDslRepository.java
+++ b/src/main/java/project/forwork/api/domain/salepost/infrastructure/SalePostQueryDslRepository.java
@@ -20,6 +20,7 @@ import project.forwork.api.domain.salepost.infrastructure.enums.SalePostSortType
 import project.forwork.api.domain.salepost.infrastructure.enums.SalesStatus;
 
 import java.math.BigDecimal;
+import java.util.Collections;
 import java.util.List;
 
 import static project.forwork.api.domain.resume.infrastructure.QResumeEntity.*;
@@ -37,7 +38,7 @@ public class SalePostQueryDslRepository {
 
     public Page<SalePostResponse> searchByCondition(SalePostSearchCond cond, Pageable pageable, SalePostSortType sortType){
 
-        OrderSpecifier orderSpecifier = createOrderSpecifier(sortType);
+        OrderSpecifier<?> orderSpecifier = createOrderSpecifier(sortType);
 
 
         List<SalePostResponse> content = queryFactory
@@ -66,6 +67,135 @@ public class SalePostQueryDslRepository {
 
         return new PageImpl<>(content, pageable, pageable.isPaged() ? content.size() : 0);
     }
+    /***
+     * 1. 기본적으로 최신 등록순으로 정렬
+     * 2. 정렬 조건 : 최신 등록순, 조회순, 많이팔린순
+     * 3. 검색 조건 : 가격(범위), 분야, 년차
+     * 4. 페이징처리 :
+     */
+    public List<SalePostResponse> findFirstPage(
+            SalePostSearchCond cond,
+            SalePostSortType sortType, int limit
+    ){
+        OrderSpecifier<?> orderSpecifier = createOrderSpecifier(sortType);
+
+        return queryFactory
+                .select(Projections.constructor(SalePostResponse.class,
+                        salePostEntity.id,
+                        salePostEntity.title,
+                        resumeEntity.price,
+                        //thumbnailImageEntity.url, TODO 썸네일
+                        salePostEntity.viewCount,
+                        salePostEntity.quantity,
+                        resumeEntity.fieldType,
+                        resumeEntity.levelType,
+                        salePostEntity.salesStatus,
+                        salePostEntity.modifiedAt))
+                .from(salePostEntity)
+                .join(salePostEntity.resumeEntity, resumeEntity)
+                //.join(salePostEntity.thumbnailImageEntity, thumbnailImageEntity) // 썸네일
+                .where(salePostEntity.salesStatus.eq(SalesStatus.SELLING),
+                        priceRangeCond(cond.getMinPrice(), cond.getMaxPrice()),
+                        fieldEqual(cond.getField()),
+                        levelEqual(cond.getLevel()))
+                .orderBy(orderSpecifier)
+                .limit(limit).fetch();
+    }
+
+    public List<SalePostResponse> findLastPage(
+            SalePostSearchCond cond,
+            SalePostSortType sortType, int limit
+    ){
+        OrderSpecifier<?> orderSpecifier = createReversedOrderSpecifier(sortType);
+
+        List<SalePostResponse> results = queryFactory
+                .select(Projections.constructor(SalePostResponse.class,
+                        salePostEntity.id,
+                        salePostEntity.title,
+                        resumeEntity.price,
+                        //thumbnailImageEntity.url, TODO 썸네일
+                        salePostEntity.viewCount,
+                        salePostEntity.quantity,
+                        resumeEntity.fieldType,
+                        resumeEntity.levelType,
+                        salePostEntity.salesStatus,
+                        salePostEntity.modifiedAt))
+                .from(salePostEntity)
+                .join(salePostEntity.resumeEntity, resumeEntity)
+                //.join(salePostEntity.thumbnailImageEntity, thumbnailImageEntity) // 썸네일
+                .where(salePostEntity.salesStatus.eq(SalesStatus.SELLING),
+                        priceRangeCond(cond.getMinPrice(), cond.getMaxPrice()),
+                        fieldEqual(cond.getField()),
+                        levelEqual(cond.getLevel()))
+                .orderBy(orderSpecifier)
+                .limit(limit).fetch();
+
+        Collections.reverse(results);
+        return results;
+    }
+
+    public List<SalePostResponse> findNextPage(
+            SalePostSearchCond cond, Long lastId,
+            SalePostSortType sortType, int limit
+    ){
+        OrderSpecifier<?> orderSpecifier = createOrderSpecifier(sortType);
+
+        return queryFactory
+                .select(Projections.constructor(SalePostResponse.class,
+                        salePostEntity.id,
+                        salePostEntity.title,
+                        resumeEntity.price,
+                        //thumbnailImageEntity.url, TODO 썸네일
+                        salePostEntity.viewCount,
+                        salePostEntity.quantity,
+                        resumeEntity.fieldType,
+                        resumeEntity.levelType,
+                        salePostEntity.salesStatus,
+                        salePostEntity.modifiedAt))
+                .from(salePostEntity)
+                .join(salePostEntity.resumeEntity, resumeEntity)
+                //.join(salePostEntity.thumbnailImageEntity, thumbnailImageEntity) // 썸네일
+                .where(salePostEntity.salesStatus.eq(SalesStatus.SELLING)
+                                .and(salePostEntity.id.lt(lastId)),
+                        priceRangeCond(cond.getMinPrice(), cond.getMaxPrice()),
+                        fieldEqual(cond.getField()),
+                        levelEqual(cond.getLevel()))
+                .orderBy(orderSpecifier)
+                .limit(limit).fetch();
+    }
+
+    public List<SalePostResponse> findPreviousPage(
+            SalePostSearchCond cond, Long lastId,
+            SalePostSortType sortType, int limit
+    ){
+        OrderSpecifier<?> orderSpecifier = createReversedOrderSpecifier(sortType);
+
+        List<SalePostResponse> results = queryFactory
+                .select(Projections.constructor(SalePostResponse.class,
+                        salePostEntity.id,
+                        salePostEntity.title,
+                        resumeEntity.price,
+                        //thumbnailImageEntity.url, TODO 썸네일
+                        salePostEntity.viewCount,
+                        salePostEntity.quantity,
+                        resumeEntity.fieldType,
+                        resumeEntity.levelType,
+                        salePostEntity.salesStatus,
+                        salePostEntity.modifiedAt))
+                .from(salePostEntity)
+                .join(salePostEntity.resumeEntity, resumeEntity)
+                //.join(salePostEntity.thumbnailImageEntity, thumbnailImageEntity) // 썸네일
+                .where(salePostEntity.salesStatus.eq(SalesStatus.SELLING)
+                                .and(salePostEntity.id.gt(lastId)),
+                        priceRangeCond(cond.getMinPrice(), cond.getMaxPrice()),
+                        fieldEqual(cond.getField()),
+                        levelEqual(cond.getLevel()))
+                .orderBy(orderSpecifier)
+                .limit(limit).fetch();
+
+        Collections.reverse(results);
+        return results;
+    }
 
     private BooleanExpression fieldEqual(FieldType field) {
         return field != null ? resumeEntity.fieldType.eq(field) : null;
@@ -89,14 +219,35 @@ public class SalePostQueryDslRepository {
         return priceCondition;
     }
 
-    private OrderSpecifier createOrderSpecifier(SalePostSortType sortType){
+    private OrderSpecifier<?> createOrderSpecifier(SalePostSortType sortType){
+
+        if(sortType == null){
+            return new OrderSpecifier<>(Order.DESC, salePostEntity.id);
+        }
+
         return switch(sortType){
             case OLD -> new OrderSpecifier<>(Order.ASC, salePostEntity.id);
+            case NEW -> new OrderSpecifier<>(Order.DESC, salePostEntity.id);
             case HIGHEST_PRICE -> new OrderSpecifier<>(Order.DESC, resumeEntity.price);
             case LOWEST_PRICE -> new OrderSpecifier<>(Order.ASC, resumeEntity.price);
             case VIEW_COUNT -> new OrderSpecifier<>(Order.DESC, salePostEntity.viewCount);
             case BEST_SELLING -> new OrderSpecifier<>(Order.ASC, salePostEntity.quantity);
-            default -> new OrderSpecifier<>(Order.DESC, salePostEntity.id);
+        };
+    }
+
+    private OrderSpecifier<?> createReversedOrderSpecifier(SalePostSortType sortType) {
+
+        if(sortType == null){
+            return new OrderSpecifier<>(Order.ASC, salePostEntity.id);
+        }
+
+        return switch (sortType) {
+            case OLD -> new OrderSpecifier<>(Order.DESC, salePostEntity.id);
+            case NEW -> new OrderSpecifier<>(Order.ASC, salePostEntity.id);
+            case HIGHEST_PRICE -> new OrderSpecifier<>(Order.ASC, resumeEntity.price);
+            case LOWEST_PRICE -> new OrderSpecifier<>(Order.DESC, resumeEntity.price);
+            case VIEW_COUNT -> new OrderSpecifier<>(Order.ASC, salePostEntity.viewCount);
+            case BEST_SELLING -> new OrderSpecifier<>(Order.DESC, salePostEntity.quantity);
         };
     }
 }

--- a/src/main/java/project/forwork/api/domain/salepost/infrastructure/enums/SalePostSortType.java
+++ b/src/main/java/project/forwork/api/domain/salepost/infrastructure/enums/SalePostSortType.java
@@ -1,5 +1,5 @@
 package project.forwork.api.domain.salepost.infrastructure.enums;
 
 public enum SalePostSortType {
-    OLD, HIGHEST_PRICE, LOWEST_PRICE, VIEW_COUNT, BEST_SELLING
+    OLD, NEW, HIGHEST_PRICE, LOWEST_PRICE, VIEW_COUNT, BEST_SELLING
 }

--- a/src/test/java/project/forwork/api/domain/salepost/infrastructure/SalePostQueryDslRepositoryTest.java
+++ b/src/test/java/project/forwork/api/domain/salepost/infrastructure/SalePostQueryDslRepositoryTest.java
@@ -41,6 +41,178 @@ class SalePostQueryDslRepositoryTest {
      */
 
     @Test
+    void 조건_없이_첫_페이지_검색(){
+        //given(상황환경 세팅)
+        SalePostSearchCond cond = new SalePostSearchCond();
+
+        //when(상황발생) 기본 정렬 최신 등록순
+        List<SalePostResponse> result = repository.findFirstPage(cond, null, 2);
+
+        //then(검증)
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getId()).isEqualTo(8L);
+        assertThat(result.get(1).getId()).isEqualTo(7L);
+    }
+// 7,5,4,3,1 back
+    @Test
+    void 조건_BACKEND_첫_페이지_검색(){
+        //given(상황환경 세팅)
+        SalePostSearchCond cond = new SalePostSearchCond();
+        cond.setField(FieldType.BACKEND);
+
+        //when(상황발생) 기본 정렬 최신 등록순
+        List<SalePostResponse> result = repository.findFirstPage(cond, null, 2);
+
+        //then(검증)
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getId()).isEqualTo(7L);
+        assertThat(result.get(1).getId()).isEqualTo(5L);
+        assertThat(result).allMatch(salePostResponse -> salePostResponse.getField().equals(FieldType.BACKEND));
+    }
+
+    @Test
+    void 조건_BACKEND_조회순_첫_페이지_검색(){
+        //given(상황환경 세팅)
+        SalePostSearchCond cond = new SalePostSearchCond();
+        cond.setField(FieldType.BACKEND);
+
+        //when(상황발생) 기본 정렬 최신 등록순
+        List<SalePostResponse> result = repository.findFirstPage(cond, SalePostSortType.VIEW_COUNT, 3);
+
+        //then(검증)
+        assertThat(result).hasSize(3);
+        assertThat(result.get(0).getId()).isEqualTo(5L);
+        assertThat(result.get(1).getId()).isEqualTo(7L);
+        assertThat(result.get(2).getId()).isEqualTo(1L);
+        assertThat(result).allMatch(salePostResponse -> salePostResponse.getField().equals(FieldType.BACKEND));
+    }
+
+    @Test
+    void 조건_BACKEND_가격_범위_조회순_첫_페이지_검색(){
+        //given(상황환경 세팅)
+        SalePostSearchCond cond = new SalePostSearchCond();
+        cond.setField(FieldType.BACKEND);
+        cond.setMinPrice(new BigDecimal("60000.00"));
+        cond.setMaxPrice(new BigDecimal("90000.00"));
+
+        //when(상황발생) 기본 정렬 최신 등록순
+        List<SalePostResponse> result = repository.findFirstPage(cond, SalePostSortType.VIEW_COUNT, 3);
+
+        //then(검증)
+        assertThat(result).hasSize(3);
+        assertThat(result.get(0).getId()).isEqualTo(5L);
+        assertThat(result.get(1).getId()).isEqualTo(1L);
+        assertThat(result.get(2).getId()).isEqualTo(4L);
+        assertThat(result).allMatch(salePostResponse -> salePostResponse.getField().equals(FieldType.BACKEND));
+    }
+
+    @Test
+    void 조건_없이_다음_페이지_검색(){
+        //given(상황환경 세팅)
+        SalePostSearchCond cond = new SalePostSearchCond();
+
+        //when(상황발생) 기본 정렬 최신 등록순
+        List<SalePostResponse> result = repository.findNextPage(cond, 7L, null, 2);
+
+        //then(검증)
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getId()).isEqualTo(6L);
+        assertThat(result.get(1).getId()).isEqualTo(5L);
+    }
+
+    @Test
+    void 조건_AI_다음_페이지_검색(){
+        //given(상황환경 세팅)
+        SalePostSearchCond cond = new SalePostSearchCond();
+        cond.setField(FieldType.AI);
+
+        //when(상황발생) 기본 정렬 최신 등록순
+        List<SalePostResponse> result = repository.findNextPage(cond, 7L,null, 1);
+
+        //then(검증)
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getId()).isEqualTo(2L);
+        assertThat(result).allMatch(salePostResponse -> salePostResponse.getField().equals(FieldType.AI));
+    }
+
+    @Test
+    void 조건_BACKEND_오랜된순_다음_페이지_검색(){
+        //given(상황환경 세팅)
+        SalePostSearchCond cond = new SalePostSearchCond();
+        cond.setField(FieldType.BACKEND);
+
+        //when(상황발생) 기본 정렬 최신 등록순
+        List<SalePostResponse> result = repository.findNextPage(cond, 5L, SalePostSortType.OLD, 2);
+
+        //then(검증)
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getId()).isEqualTo(1L);
+        assertThat(result.get(1).getId()).isEqualTo(4L);
+        assertThat(result).allMatch(salePostResponse -> salePostResponse.getField().equals(FieldType.BACKEND));
+    }
+
+    @Test
+    void 조건_없이_이전_페이지_검색(){
+        //given(상황환경 세팅)
+        SalePostSearchCond cond = new SalePostSearchCond();
+
+        //when(상황발생) 기본 정렬 최신 등록순
+        List<SalePostResponse> result = repository.findPreviousPage(cond, 1L, null, 2);
+
+        //then(검증)
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getId()).isEqualTo(4L);
+        assertThat(result.get(1).getId()).isEqualTo(2L);
+    }
+
+    @Test
+    void 조건_SENIOR_이전_페이지_검색(){
+        //given(상황환경 세팅)
+        SalePostSearchCond cond = new SalePostSearchCond();
+        cond.setLevel(LevelType.SENIOR);
+
+        //when(상황발생) 기본 정렬 최신 등록순
+        List<SalePostResponse> result = repository.findNextPage(cond, 6L,null, 2);
+
+        //then(검증)
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getId()).isEqualTo(2L);
+        assertThat(result.get(1).getId()).isEqualTo(1L);
+        assertThat(result).allMatch(salePostResponse -> salePostResponse.getLevel().equals(LevelType.SENIOR));
+    }
+
+    @Test
+    void 조건_없이_마지막_페이지_검색(){
+        //given(상황환경 세팅)
+        SalePostSearchCond cond = new SalePostSearchCond();
+
+        //when(상황발생) 기본 정렬 최신 등록순
+        List<SalePostResponse> result = repository.findLastPage(cond, null, 2);
+
+        //then(검증)
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getId()).isEqualTo(2L);
+        assertThat(result.get(1).getId()).isEqualTo(1L);
+    }
+
+    @Test
+    void 조건_BACKEND_조회순_마지막_페이지_검색(){
+        //given(상황환경 세팅)
+        SalePostSearchCond cond = new SalePostSearchCond();
+        cond.setField(FieldType.BACKEND);
+
+        //when(상황발생) 기본 정렬 최신 등록순
+        List<SalePostResponse> result = repository.findLastPage(cond, SalePostSortType.VIEW_COUNT, 3);
+
+        //then(검증)
+        assertThat(result).hasSize(3);
+        assertThat(result.get(0).getId()).isEqualTo(7L);
+        assertThat(result.get(1).getId()).isEqualTo(1L);
+        assertThat(result.get(2).getId()).isEqualTo(4L);
+        assertThat(result).allMatch(salePostResponse -> salePostResponse.getField().equals(FieldType.BACKEND));
+    }
+
+    @Test
     void 조건_없이_검색(){
         //given(상황환경 세팅)
         SalePostSearchCond cond = new SalePostSearchCond();

--- a/src/test/java/project/forwork/api/mock/TestClockHolder.java
+++ b/src/test/java/project/forwork/api/mock/TestClockHolder.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.RequiredArgsConstructor;
 import project.forwork.api.common.service.port.ClockHolder;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Date;
 @AllArgsConstructor
@@ -13,6 +14,7 @@ public class TestClockHolder implements ClockHolder {
 
     private long mills;
     private LocalDateTime localDateTime;
+    private LocalDate localDate;
 
     public TestClockHolder(long mills) {
         this.mills = mills;
@@ -36,7 +38,10 @@ public class TestClockHolder implements ClockHolder {
     public LocalDateTime now() {
         return localDateTime;
     }
-
+    @Override
+    public LocalDate nowDate(){
+        return localDate;
+    }
     @Override
     public Date convertExpiredDateFrom(long millis) {
         long expiredMillis = millis * 1000 + millis();

--- a/src/test/resources/sql/resume-test-data.sql
+++ b/src/test/resources/sql/resume-test-data.sql
@@ -1,13 +1,13 @@
 INSERT INTO `resumes`
 (`price`, `registered_at`, `modified_at`, `resume_id`, `seller_id`, `architecture_image_url`, `resume_url`, `description`, `field`, `level`, `status`)
 VALUES
-    ('80000', '2024-09-03 00:18:39', '2024-09-03 00:18:39', '1', '2', 'http://docs.google.com/presentation/d/1AT954aQPzBf0vm47yYqDDfGtbkejSmJ9/edit',
+    ('80000', '2024-09-03 00:18:39', '2024-09-02 00:18:39', '1', '2', 'http://docs.google.com/presentation/d/1AT954aQPzBf0vm47yYqDDfGtbkejSmJ9/edit',
      'http://docs.google.com/presentation/d/1AT954aQPzBf0vm47yYqDDfGtbkejSmJ9/edit', 'test1', 'BACKEND', 'SENIOR', 'PENDING');
 
 INSERT INTO `resumes`
 (`price`, `registered_at`, `modified_at`, `resume_id`, `seller_id`, `architecture_image_url`, `resume_url`, `description`, `field`, `level`, `status`)
 VALUES
-    ('80000', '2024-09-03 00:18:39', '2024-09-03 00:18:39', '2', '1', 'http://docs.google.com/presentation/d/1AT954aQPzBf0vm47yYqDDfGtbkejSmJ9/edit',
+    ('80000', '2024-09-03 00:18:39', '2024-09-10 00:18:39', '2', '1', 'http://docs.google.com/presentation/d/1AT954aQPzBf0vm47yYqDDfGtbkejSmJ9/edit',
      'http://docs.google.com/presentation/d/1AT954aQPzBf0vm47yYqDDfGtbkejSmJ9/edit', 'test2', 'AI', 'SENIOR', 'REJECTED');
 
 INSERT INTO `resumes`
@@ -31,17 +31,17 @@ VALUES
 INSERT INTO `resumes`
 (`price`, `registered_at`, `modified_at`, `resume_id`, `seller_id`, `architecture_image_url`, `resume_url`, `description`, `field`, `level`, `status`)
 VALUES
-    ('65000', '2024-09-06 00:18:39', '2024-09-05 00:18:39', '6', '1', 'http://docs.google.com/presentation/d/1AT954aQPzBf0vm47yYqDDfGtbkejSmJ9/edit',
+    ('65000', '2024-09-06 00:18:39', '2024-09-06 00:18:39', '6', '1', 'http://docs.google.com/presentation/d/1AT954aQPzBf0vm47yYqDDfGtbkejSmJ9/edit',
      'http://docs.google.com/presentation/d/1AT954aQPzBf0vm47yYqDDfGtbkejSmJ9/edit', 'test6', 'FRONTEND', 'SENIOR', 'ACTIVE');
 
 INSERT INTO `resumes`
 (`price`, `registered_at`, `modified_at`, `resume_id`, `seller_id`, `architecture_image_url`, `resume_url`, `description`, `field`, `level`, `status`)
 VALUES
-    ('30000', '2024-09-07 00:18:39', '2024-09-05 00:18:39', '7', '2', 'http://docs.google.com/presentation/d/1AT954aQPzBf0vm47yYqDDfGtbkejSmJ9/edit',
+    ('30000', '2024-09-07 00:18:39', '2024-09-07 00:18:39', '7', '2', 'http://docs.google.com/presentation/d/1AT954aQPzBf0vm47yYqDDfGtbkejSmJ9/edit',
      'http://docs.google.com/presentation/d/1AT954aQPzBf0vm47yYqDDfGtbkejSmJ9/edit', 'test7', 'BACKEND', 'NEW', 'ACTIVE');
 
 INSERT INTO `resumes`
 (`price`, `registered_at`, `modified_at`, `resume_id`, `seller_id`, `architecture_image_url`, `resume_url`, `description`, `field`, `level`, `status`)
 VALUES
-    ('99000', '2024-09-07 00:18:39', '2024-09-05 00:18:39', '8', '1', 'http://docs.google.com/presentation/d/1AT954aQPzBf0vm47yYqDDfGtbkejSmJ9/edit',
+    ('99000', '2024-09-07 00:18:39', '2024-09-08 00:18:39', '8', '1', 'http://docs.google.com/presentation/d/1AT954aQPzBf0vm47yYqDDfGtbkejSmJ9/edit',
      'http://docs.google.com/presentation/d/1AT954aQPzBf0vm47yYqDDfGtbkejSmJ9/edit', 'test8', 'AI', 'NEW', 'ACTIVE');


### PR DESCRIPTION
 - 기존에 페이징 처리를 할때 offset을 사용하였는데 계획을 전면 수정 해서 offset은 제거 하고 이전,다음,처음,마지막 페이지 버튼 기능으로 변경 
하였습니다.
- 관리자가 볼 수 있는 판매 요청 이력서 목록을 기존 검색조건을 전부 제거하고 1일, 1주, 1달 단위로 검색 조건을 변경, 추가로 요청에 대한 상태도 같이 필터링 조건에 포함 하였습니다.
- 변경 한 부분에 대해 테스트 코드 작성 하였습니다.