### PR TITLE
feat: 인증 헤더 형태로 JWT 토큰 관리 기능

### DIFF
--- a/src/main/java/project/forwork/api/common/config/swageer/SwaggerConfig.java
+++ b/src/main/java/project/forwork/api/common/config/swageer/SwaggerConfig.java
@@ -3,7 +3,11 @@ package project.forwork.api.common.config.swageer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.v3.core.jackson.ModelResolver;
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
 import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
@@ -15,7 +19,15 @@ import org.springframework.core.annotation.Order;
 @OpenAPIDefinition(
         info = @Info(title = "For-work Service Api 명세서",
                 description = "Spring Boot 기반 RESTful Api",
-                version = "v1.0.0")
+                version = "v1.0.0"),
+        security = @SecurityRequirement(name = "bearerAuth")
+)
+@SecurityScheme(
+        name = "bearerAuth",
+        type = SecuritySchemeType.HTTP,
+        scheme = "bearer",
+        bearerFormat = "JWT",
+        in = SecuritySchemeIn.HEADER
 )
 public class SwaggerConfig {
     @Bean

--- a/src/main/java/project/forwork/api/common/infrastructure/MailSenderImpl.java
+++ b/src/main/java/project/forwork/api/common/infrastructure/MailSenderImpl.java
@@ -12,7 +12,7 @@ import project.forwork.api.common.service.port.MailSender;
 public class MailSenderImpl implements MailSender {
     private final JavaMailSender javaMailSender;
 
-    @Async // TODO 비동기 공부필요
+    @Async // TODO 공부필요 1. 톰캣의 쓰레드, 스프링 쓰레드 별개의 것 2. 하지만 둘다 JVM 리소스 사용
     @Override
     public void send(String email, String title, String content) {
         SimpleMailMessage message = new SimpleMailMessage();

--- a/src/main/java/project/forwork/api/domain/cart/controller/CartController.java
+++ b/src/main/java/project/forwork/api/domain/cart/controller/CartController.java
@@ -26,6 +26,6 @@ public class CartController {
             @Parameter(hidden = true) @Current CurrentUser currentUser
     ){
         cartService.register(currentUser);
-        return Api.CREATED("장바구니 생성");
+        return Api.CREATED("장바구니 생성 성공");
     }
 }

--- a/src/main/java/project/forwork/api/domain/orderresume/service/SendPurchaseResumeService.java
+++ b/src/main/java/project/forwork/api/domain/orderresume/service/SendPurchaseResumeService.java
@@ -31,7 +31,6 @@ public class SendPurchaseResumeService {
         purchaseResponses.forEach(this::sendEmail);
     }
 
-    @Async //TODO 공부필요 1. 톰캣의 쓰레드, 스프링 쓰레드 별개의 것 2. 하지만 둘다 JVM 리소스 사용
     public void sendEmail(PurchaseResponse purchaseResponse){
         String title = "for-work 구매 이력서 : " + purchaseResponse.getSalesPostTitle();
         String content = "주문 번호 #" + purchaseResponse.getOrderId() +" <URL> : "+ purchaseResponse.getResumeUrl();

--- a/src/main/java/project/forwork/api/domain/token/controller/TokenCookiesController.java
+++ b/src/main/java/project/forwork/api/domain/token/controller/TokenCookiesController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import project.forwork.api.common.api.Api;
 import project.forwork.api.domain.token.service.TokenCookieService;
+import project.forwork.api.domain.token.service.TokenHeaderService;
 
 @RestController
 @RequiredArgsConstructor
@@ -17,7 +18,8 @@ import project.forwork.api.domain.token.service.TokenCookieService;
 @Tag(name = "TokenCookiesController")
 public class TokenCookiesController {
 
-    private final TokenCookieService tokenCookieService;
+    //private final TokenCookieService tokenCookieService;
+    private final TokenHeaderService tokenHeaderService;
 
     @Operation(summary = "Access Token 재발급 API", description = "Refresh Token을 이용해 새로운 Access Token을 발급")
     @PostMapping("/reissue")
@@ -25,7 +27,16 @@ public class TokenCookiesController {
             HttpServletRequest request,
             HttpServletResponse response
     ) {
-        tokenCookieService.reissueRefreshTokenAndCookies(request, response);
+        tokenHeaderService.reissueRefreshTokenAndHeaders(request, response);
         return Api.OK("Access Token 재발급 성공");
     }
+/*    @Operation(summary = "Access Token 재발급 API", description = "Refresh Token을 이용해 새로운 Access Token을 발급")
+    @PostMapping("/reissue")
+    public Api<String> reissueAccessToken(
+            HttpServletRequest request,
+            HttpServletResponse response
+    ) {
+        tokenCookieService.reissueRefreshTokenAndCookies(request, response);
+        return Api.OK("Access Token 재발급 성공");
+    }*/
 }

--- a/src/main/java/project/forwork/api/domain/token/service/TokenHeaderService.java
+++ b/src/main/java/project/forwork/api/domain/token/service/TokenHeaderService.java
@@ -1,0 +1,59 @@
+package project.forwork.api.domain.token.service;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import project.forwork.api.common.error.TokenErrorCode;
+import project.forwork.api.common.exception.ApiException;
+import project.forwork.api.domain.token.model.TokenResponse;
+import project.forwork.api.domain.user.model.User;
+
+@Service
+@RequiredArgsConstructor
+public class TokenHeaderService {
+    public static final String ACCESS_TOKEN_HEADER = "Authorization";
+    public static final String REFRESH_TOKEN_HEADER = "Refresh-Token";
+
+    private final TokenService tokenService;
+
+    public TokenResponse addTokenToHeaders(HttpServletResponse response, User loginUser) {
+        TokenResponse tokenResponse = tokenService.issueTokenResponse(loginUser);
+        setHeaderByTokenResponse(response, tokenResponse);
+
+        return tokenResponse;
+    }
+
+    public void expireTokensInHeaders(HttpServletRequest request, HttpServletResponse response) {
+        response.setHeader(ACCESS_TOKEN_HEADER, "");
+        response.setHeader(REFRESH_TOKEN_HEADER, "");
+    }
+
+    public void expiredRefreshTokenAndHeaders(
+            Long userId,
+            HttpServletRequest request,
+            HttpServletResponse response
+    ) {
+        tokenService.deleteRefreshToken(userId);
+        expireTokensInHeaders(request, response);
+    }
+
+    public void reissueRefreshTokenAndHeaders(HttpServletRequest request, HttpServletResponse response) {
+        String refreshToken = extractTokenFromHeader(request, REFRESH_TOKEN_HEADER);
+        TokenResponse tokenResponse = tokenService.reissueTokenResponse(refreshToken);
+        setHeaderByTokenResponse(response, tokenResponse);
+    }
+
+    public String extractTokenFromHeader(HttpServletRequest request, String headerName) {
+        String token = request.getHeader(headerName);
+        if (token == null || !token.startsWith("Bearer ")) {
+            throw new ApiException(TokenErrorCode.TOKEN_NOT_FOUND);
+        }
+        return token.substring(7); // "Bearer " 이후의 토큰 값만 반환
+    }
+
+    private void setHeaderByTokenResponse(HttpServletResponse response, TokenResponse tokenResponse) {
+        response.setHeader(ACCESS_TOKEN_HEADER, "Bearer " + tokenResponse.getAccessToken());
+        response.setHeader(REFRESH_TOKEN_HEADER, "Bearer " + tokenResponse.getRefreshToken());
+    }
+}

--- a/src/main/java/project/forwork/api/domain/token/service/TokenService.java
+++ b/src/main/java/project/forwork/api/domain/token/service/TokenService.java
@@ -22,7 +22,6 @@ public class TokenService {
 
     public static final String PREFIX_TOKEN_KEY = "refreshToken:userId:";
     private final TokenHelperIfs tokenHelper;
-    private final ClockHolder clockHolder;
     private final RedisUtils redisUtils;
     public TokenResponse issueTokenResponse(User user) {
 

--- a/src/main/java/project/forwork/api/domain/user/controller/UserOpenApiController.java
+++ b/src/main/java/project/forwork/api/domain/user/controller/UserOpenApiController.java
@@ -55,13 +55,13 @@ public class UserOpenApiController {
 
     @Operation(summary = "회원 로그인 API", description = "ID, 패스워드 입력")
     @PostMapping("/login")
-    public Api<UserResponse> login(
+    public Api<LoginResponse> login(
             @Valid @RequestBody
             UserLoginRequest userLoginRequest,
             HttpServletResponse response
     ){
-        UserResponse userResponse = loginService.login(response, userLoginRequest);
-        return Api.OK(userResponse);
+        LoginResponse loginResponse = loginService.login(response, userLoginRequest);
+        return Api.OK(loginResponse);
     }
 
     @Operation(summary = "임시 비밀번호 발급 API", description = "계정의 이메일, 성함 입력")

--- a/src/main/java/project/forwork/api/domain/user/controller/model/LoginResponse.java
+++ b/src/main/java/project/forwork/api/domain/user/controller/model/LoginResponse.java
@@ -1,0 +1,25 @@
+package project.forwork.api.domain.user.controller.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import project.forwork.api.domain.token.model.TokenResponse;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class LoginResponse {
+    private Long userId;
+    private String accessToken;
+    private String refreshToken;
+
+    public static LoginResponse from(Long userId, TokenResponse tokenResponse){
+        return LoginResponse.builder()
+                .userId(userId)
+                .accessToken(tokenResponse.getAccessToken())
+                .refreshToken(tokenResponse.getRefreshToken())
+                .build();
+    }
+}

--- a/src/main/java/project/forwork/api/domain/user/service/UserService.java
+++ b/src/main/java/project/forwork/api/domain/user/service/UserService.java
@@ -14,6 +14,7 @@ import project.forwork.api.common.service.port.MailSender;
 import project.forwork.api.common.service.port.RedisUtils;
 import project.forwork.api.common.service.port.UuidHolder;
 import project.forwork.api.domain.token.service.TokenCookieService;
+import project.forwork.api.domain.token.service.TokenHeaderService;
 import project.forwork.api.domain.user.controller.model.*;
 import project.forwork.api.domain.user.model.User;
 import project.forwork.api.domain.user.service.port.UserRepository;
@@ -28,7 +29,8 @@ public class UserService {
     public static final String EMAIL_PREFIX = "email:";
 
     private final UserRepository userRepository;
-    private final TokenCookieService tokenCookieService;
+    //private final TokenCookieService tokenCookieService;
+    private final TokenHeaderService tokenHeaderService;
     private final MailSender mailSender;
     private final UuidHolder uuidHolder;
     private final RedisUtils redisUtils;
@@ -60,7 +62,7 @@ public class UserService {
             HttpServletResponse response
     ){
         User user = userRepository.getByIdWithThrow(currentUser.getId());
-        tokenCookieService.expiredCookiesAndRefreshToken(user.getId(), request, response);
+        tokenHeaderService.expiredRefreshTokenAndHeaders(user.getId(), request, response);
         userRepository.delete(user);
     }
 

--- a/src/test/java/project/forwork/api/domain/user/service/UserServiceTest.java
+++ b/src/test/java/project/forwork/api/domain/user/service/UserServiceTest.java
@@ -12,6 +12,7 @@ import project.forwork.api.common.domain.CurrentUser;
 import project.forwork.api.common.exception.ApiException;
 import project.forwork.api.common.service.port.RedisUtils;
 import project.forwork.api.domain.token.service.TokenCookieService;
+import project.forwork.api.domain.token.service.TokenHeaderService;
 import project.forwork.api.domain.user.controller.model.EmailVerifyRequest;
 import project.forwork.api.domain.user.controller.model.PasswordModifyRequest;
 import project.forwork.api.domain.user.controller.model.PasswordVerifyRequest;
@@ -36,7 +37,7 @@ class UserServiceTest {
     private TestUuidHolder testUuidHolder;
     private FakeMailSender fakeMailSender;
     @Mock
-    private TokenCookieService tokenCookieService;
+    private TokenHeaderService tokenHeaderService;
     @Mock
     private RedisUtils redisUtils;
     @BeforeEach
@@ -49,7 +50,7 @@ class UserServiceTest {
                 .userRepository(fakeUserRepository)
                 .redisUtils(redisUtils)
                 .uuidHolder(testUuidHolder)
-                .tokenCookieService(tokenCookieService)
+                .tokenHeaderService(tokenHeaderService)
                 .build();
 
         User user = User.builder()
@@ -164,7 +165,7 @@ class UserServiceTest {
 
         //then(검증)
         assertThat(fakeUserRepository.findById(currentUser.getId())).isEmpty();
-        verify(tokenCookieService).expiredCookiesAndRefreshToken(eq(currentUser.getId()), eq(request), eq(response));
+        verify(tokenHeaderService).expiredRefreshTokenAndHeaders(eq(currentUser.getId()), eq(request), eq(response));
     }
 
     @Test


### PR DESCRIPTION
- TokenHeaderService를 작성하여 Request Header에 Access, Refresh Token 값을 넣어서 반환하는 로직 추가 하였습니다.
- TokenHeaderService 사용에 따른 인터셉터 로직 변경 및 로그인시 TokenResponse를 반환하여 클라이언트 측에서 토큰을 관리 할 수 있도록 로직을 작성 하였습니다. Resolves: #75