### PR TITLE
feat: mail-log 기능 개발

### DIFF
--- a/src/main/java/project/forwork/api/domain/maillog/infrastructure/MailLogEntity.java
+++ b/src/main/java/project/forwork/api/domain/maillog/infrastructure/MailLogEntity.java
@@ -1,0 +1,64 @@
+package project.forwork.api.domain.maillog.infrastructure;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import project.forwork.api.common.infrastructure.BaseTimeEntity;
+import project.forwork.api.domain.maillog.infrastructure.enums.Result;
+import project.forwork.api.domain.maillog.model.MailLog;
+import project.forwork.api.domain.orderresume.infrastructure.enums.OrderResumeStatus;
+
+@Entity
+@Table(name = "mail_logs")
+@Getter
+@SuperBuilder
+@EqualsAndHashCode(callSuper = true)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MailLogEntity extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "mail_log_id")
+    private Long id;
+
+    @Column(name = "email", nullable = false)
+    private String email;
+
+    @Column(name = "request_id", nullable = false)
+    private String requestId;
+
+    @Column(name = "resume_id", nullable = false)
+    private Long resumeId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Result result;
+
+    @Column(name = "error_response")
+    private String errorResponse;
+
+    public static MailLogEntity from(MailLog mailLog){
+        MailLogEntity mailLogEntity = new MailLogEntity();
+        mailLogEntity.id = mailLog.getId();
+        mailLogEntity.email = mailLog.getEmail();
+        mailLogEntity.requestId = mailLog.getRequestId();
+        mailLogEntity.resumeId = mailLog.getResumeId();
+        mailLogEntity.result = mailLog.getResult();
+        mailLogEntity.errorResponse = mailLog.getErrorResponse();
+        return  mailLogEntity;
+    }
+
+    public MailLog toModel(){
+        return MailLog.builder()
+                .id(id)
+                .email(email)
+                .requestId(requestId)
+                .resumeId(resumeId)
+                .result(result)
+                .errorResponse(errorResponse)
+                .build();
+    }
+}

--- a/src/main/java/project/forwork/api/domain/maillog/infrastructure/MailLogJpaRepository.java
+++ b/src/main/java/project/forwork/api/domain/maillog/infrastructure/MailLogJpaRepository.java
@@ -1,0 +1,6 @@
+package project.forwork.api.domain.maillog.infrastructure;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MailLogJpaRepository extends JpaRepository<MailLogEntity, Long> {
+}

--- a/src/main/java/project/forwork/api/domain/maillog/infrastructure/MailLogRepositoryImpl.java
+++ b/src/main/java/project/forwork/api/domain/maillog/infrastructure/MailLogRepositoryImpl.java
@@ -1,0 +1,17 @@
+package project.forwork.api.domain.maillog.infrastructure;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import project.forwork.api.domain.maillog.model.MailLog;
+import project.forwork.api.domain.maillog.service.port.MailLogRepository;
+
+@RequiredArgsConstructor
+@Repository
+public class MailLogRepositoryImpl implements MailLogRepository {
+
+    private final MailLogJpaRepository mailLogJpaRepository;
+    @Override
+    public MailLog save(MailLog mailLog) {
+        return mailLogJpaRepository.save(MailLogEntity.from(mailLog)).toModel();
+    }
+}

--- a/src/main/java/project/forwork/api/domain/maillog/infrastructure/enums/Result.java
+++ b/src/main/java/project/forwork/api/domain/maillog/infrastructure/enums/Result.java
@@ -1,0 +1,26 @@
+package project.forwork.api.domain.maillog.infrastructure.enums;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import project.forwork.api.common.infrastructure.enums.FieldType;
+
+@AllArgsConstructor
+@Getter
+public enum Result {
+    SUCCESS("발송 성공"),
+    FAIL("발송 실패"),
+    ;
+
+    private String description;
+
+    @JsonCreator
+    public static Result from(String s) {
+        for (Result status : Result.values()) {
+            if (status.name().equalsIgnoreCase(s)) {
+                return status;
+            }
+        }
+        throw new IllegalArgumentException("Invalid Result: " + s);
+    }
+}

--- a/src/main/java/project/forwork/api/domain/maillog/model/MailLog.java
+++ b/src/main/java/project/forwork/api/domain/maillog/model/MailLog.java
@@ -1,0 +1,37 @@
+package project.forwork.api.domain.maillog.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import project.forwork.api.domain.maillog.infrastructure.enums.Result;
+
+@Builder
+@AllArgsConstructor
+@Getter
+public class MailLog {
+    private final Long id;
+    private final String email;
+    private final String requestId;
+    private final Long resumeId;
+    private final Result result;
+    private final String errorResponse;
+
+    public static MailLog create(String email, String requestId, Long resumeId, Exception e){
+        return MailLog.builder()
+                .email(email)
+                .requestId(requestId)
+                .resumeId(resumeId)
+                .result(Result.FAIL)
+                .errorResponse(e.getMessage())
+                .build();
+    }
+
+    public static MailLog create(String email, String requestId, Long resumeId){
+        return MailLog.builder()
+                .email(email)
+                .requestId(requestId)
+                .resumeId(resumeId)
+                .result(Result.SUCCESS)
+                .build();
+    }
+}

--- a/src/main/java/project/forwork/api/domain/maillog/service/MailLogService.java
+++ b/src/main/java/project/forwork/api/domain/maillog/service/MailLogService.java
@@ -1,0 +1,33 @@
+package project.forwork.api.domain.maillog.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import project.forwork.api.domain.maillog.model.MailLog;
+import project.forwork.api.domain.maillog.service.port.MailLogRepository;
+import project.forwork.api.domain.order.model.Order;
+import project.forwork.api.domain.order.service.port.OrderRepository;
+import project.forwork.api.domain.orderresume.controller.model.PurchaseResponse;
+
+@Service
+@RequiredArgsConstructor
+public class MailLogService {
+
+    private final MailLogRepository mailLogRepository;
+    private final OrderRepository orderRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void registerFailLog(PurchaseResponse body, Exception e){
+        Order order = orderRepository.getByIdWithThrow(body.getOrderId());
+        MailLog mailLog = MailLog.create(body.getEmail(), order.getRequestId(), body.getResumeId(), e);
+        mailLogRepository.save(mailLog);
+    }
+
+    @Transactional
+    public void registerSuccessLog(PurchaseResponse body){
+        Order order = orderRepository.getByIdWithThrow(body.getOrderId());
+        MailLog mailLog = MailLog.create(body.getEmail(), order.getRequestId(), body.getResumeId());
+        mailLogRepository.save(mailLog);
+    }
+}

--- a/src/main/java/project/forwork/api/domain/maillog/service/port/MailLogRepository.java
+++ b/src/main/java/project/forwork/api/domain/maillog/service/port/MailLogRepository.java
@@ -1,0 +1,7 @@
+package project.forwork.api.domain.maillog.service.port;
+
+import project.forwork.api.domain.maillog.model.MailLog;
+
+public interface MailLogRepository {
+    MailLog save(MailLog mailLog);
+}


### PR DESCRIPTION
- 구매 확정 이력서에 대해 이메일을 보낼때 관련 정보 log 테이블에 저장 기능 추가 하였습니다.
- 메일 발송 성공시 email, resume-id, request-id 저장
- 메일 발송 실패시 email, resume-id, request-id, exception message 저장 Resolves: #118