### PR TITLE
Refactor/sort cond (판매 요청 날짜순에 대한 정렬 조건)

### DIFF
--- a/load_test/sales-pot-page-test.jmx
+++ b/load_test/sales-pot-page-test.jmx
@@ -195,7 +195,7 @@
           <stringProp name="HTTPSampler.method">GET</stringProp>
           <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
           <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
-          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="사용자 정의 변수들">
             <collectionProp name="Arguments.arguments"/>
           </elementProp>
         </HTTPSamplerProxy>
@@ -229,7 +229,7 @@
           <stringProp name="HTTPSampler.method">GET</stringProp>
           <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
           <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
-          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="사용자 정의 변수들">
             <collectionProp name="Arguments.arguments"/>
           </elementProp>
         </HTTPSamplerProxy>
@@ -272,7 +272,7 @@
           <stringProp name="HTTPSampler.method">GET</stringProp>
           <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
           <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
-          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="사용자 정의 변수들">
             <collectionProp name="Arguments.arguments"/>
           </elementProp>
         </HTTPSamplerProxy>
@@ -315,7 +315,7 @@
           <stringProp name="HTTPSampler.method">GET</stringProp>
           <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
           <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
-          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="사용자 정의 변수들">
             <collectionProp name="Arguments.arguments"/>
           </elementProp>
         </HTTPSamplerProxy>
@@ -358,7 +358,7 @@
           <stringProp name="HTTPSampler.method">GET</stringProp>
           <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
           <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
-          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="사용자 정의 변수들">
             <collectionProp name="Arguments.arguments"/>
           </elementProp>
         </HTTPSamplerProxy>
@@ -383,7 +383,7 @@
           <stringProp name="HTTPSampler.method">GET</stringProp>
           <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
           <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
-          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="사용자 정의 변수들">
             <collectionProp name="Arguments.arguments"/>
           </elementProp>
         </HTTPSamplerProxy>
@@ -586,7 +586,7 @@
           <stringProp name="HTTPSampler.method">GET</stringProp>
           <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
           <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
-          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="사용자 정의 변수들">
             <collectionProp name="Arguments.arguments"/>
           </elementProp>
         </HTTPSamplerProxy>
@@ -611,7 +611,7 @@
           <stringProp name="HTTPSampler.method">GET</stringProp>
           <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
           <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
-          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="사용자 정의 변수들">
             <collectionProp name="Arguments.arguments"/>
           </elementProp>
         </HTTPSamplerProxy>
@@ -636,7 +636,7 @@
           <stringProp name="HTTPSampler.method">GET</stringProp>
           <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
           <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
-          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="사용자 정의 변수들">
             <collectionProp name="Arguments.arguments"/>
           </elementProp>
         </HTTPSamplerProxy>
@@ -661,7 +661,7 @@
           <stringProp name="HTTPSampler.method">GET</stringProp>
           <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
           <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
-          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="사용자 정의 변수들">
             <collectionProp name="Arguments.arguments"/>
           </elementProp>
         </HTTPSamplerProxy>
@@ -686,7 +686,7 @@
           <stringProp name="HTTPSampler.method">GET</stringProp>
           <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
           <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
-          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="사용자 정의 변수들">
             <collectionProp name="Arguments.arguments"/>
           </elementProp>
         </HTTPSamplerProxy>
@@ -711,7 +711,7 @@
           <stringProp name="HTTPSampler.method">GET</stringProp>
           <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
           <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
-          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="사용자 정의 변수들">
             <collectionProp name="Arguments.arguments"/>
           </elementProp>
         </HTTPSamplerProxy>
@@ -736,7 +736,7 @@
           <stringProp name="HTTPSampler.method">GET</stringProp>
           <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
           <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
-          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="사용자 정의 변수들">
             <collectionProp name="Arguments.arguments"/>
           </elementProp>
         </HTTPSamplerProxy>
@@ -937,7 +937,7 @@
           <stringProp name="HTTPSampler.method">GET</stringProp>
           <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
           <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
-          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="사용자 정의 변수들">
             <collectionProp name="Arguments.arguments"/>
           </elementProp>
         </HTTPSamplerProxy>
@@ -962,7 +962,7 @@
           <stringProp name="HTTPSampler.method">GET</stringProp>
           <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
           <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
-          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="사용자 정의 변수들">
             <collectionProp name="Arguments.arguments"/>
           </elementProp>
         </HTTPSamplerProxy>
@@ -987,7 +987,7 @@
           <stringProp name="HTTPSampler.method">GET</stringProp>
           <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
           <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
-          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="사용자 정의 변수들">
             <collectionProp name="Arguments.arguments"/>
           </elementProp>
         </HTTPSamplerProxy>
@@ -1012,7 +1012,7 @@
           <stringProp name="HTTPSampler.method">GET</stringProp>
           <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
           <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
-          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="사용자 정의 변수들">
             <collectionProp name="Arguments.arguments"/>
           </elementProp>
         </HTTPSamplerProxy>
@@ -1037,7 +1037,7 @@
           <stringProp name="HTTPSampler.method">GET</stringProp>
           <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
           <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
-          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="사용자 정의 변수들">
             <collectionProp name="Arguments.arguments"/>
           </elementProp>
         </HTTPSamplerProxy>
@@ -1062,7 +1062,7 @@
           <stringProp name="HTTPSampler.method">GET</stringProp>
           <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
           <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
-          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="사용자 정의 변수들">
             <collectionProp name="Arguments.arguments"/>
           </elementProp>
         </HTTPSamplerProxy>
@@ -1087,7 +1087,7 @@
           <stringProp name="HTTPSampler.method">GET</stringProp>
           <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
           <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
-          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="사용자 정의 변수들">
             <collectionProp name="Arguments.arguments"/>
           </elementProp>
         </HTTPSamplerProxy>
@@ -1126,7 +1126,7 @@
           <stringProp name="HTTPSampler.method">POST</stringProp>
           <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
           <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
-          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="사용자 정의 변수들">
             <collectionProp name="Arguments.arguments"/>
           </elementProp>
         </HTTPSamplerProxy>
@@ -1229,7 +1229,7 @@
           <stringProp name="HTTPSampler.method">GET</stringProp>
           <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
           <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
-          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="사용자 정의 변수들">
             <collectionProp name="Arguments.arguments"/>
           </elementProp>
         </HTTPSamplerProxy>
@@ -1254,7 +1254,7 @@
           <stringProp name="HTTPSampler.method">GET</stringProp>
           <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
           <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
-          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="사용자 정의 변수들">
             <collectionProp name="Arguments.arguments"/>
           </elementProp>
         </HTTPSamplerProxy>
@@ -1272,17 +1272,17 @@
         </hashTree>
       </hashTree>
       <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="first-page">
-        <intProp name="ThreadGroup.num_threads">2000</intProp>
+        <intProp name="ThreadGroup.num_threads">2</intProp>
         <intProp name="ThreadGroup.ramp_time">10</intProp>
         <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
         <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
         <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller">
-          <stringProp name="LoopController.loops">10</stringProp>
+          <stringProp name="LoopController.loops">2</stringProp>
           <boolProp name="LoopController.continue_forever">false</boolProp>
         </elementProp>
       </ThreadGroup>
       <hashTree>
-        <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="true">
+        <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree">
           <boolProp name="ResultCollector.error_logging">false</boolProp>
           <objProp>
             <name>saveConfig</name>
@@ -1356,7 +1356,7 @@
           <stringProp name="filename"></stringProp>
         </ResultCollector>
         <hashTree/>
-        <kg.apc.jmeter.vizualizers.CorrectedResultCollector guiclass="kg.apc.jmeter.vizualizers.TransactionsPerSecondGui" testclass="kg.apc.jmeter.vizualizers.CorrectedResultCollector" testname="jp@gc - Transactions per Second" enabled="true">
+        <kg.apc.jmeter.vizualizers.CorrectedResultCollector guiclass="kg.apc.jmeter.vizualizers.TransactionsPerSecondGui" testclass="kg.apc.jmeter.vizualizers.CorrectedResultCollector" testname="jp@gc - Transactions per Second">
           <boolProp name="ResultCollector.error_logging">false</boolProp>
           <objProp>
             <name>saveConfig</name>
@@ -1455,7 +1455,7 @@
           <stringProp name="HTTPSampler.method">GET</stringProp>
           <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
           <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
-          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="사용자 정의 변수들">
             <collectionProp name="Arguments.arguments"/>
           </elementProp>
         </HTTPSamplerProxy>
@@ -1480,7 +1480,7 @@
           <stringProp name="HTTPSampler.method">GET</stringProp>
           <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
           <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
-          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="사용자 정의 변수들">
             <collectionProp name="Arguments.arguments"/>
           </elementProp>
         </HTTPSamplerProxy>
@@ -1505,7 +1505,7 @@
           <stringProp name="HTTPSampler.method">GET</stringProp>
           <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
           <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
-          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="사용자 정의 변수들">
             <collectionProp name="Arguments.arguments"/>
           </elementProp>
         </HTTPSamplerProxy>
@@ -1530,7 +1530,7 @@
           <stringProp name="HTTPSampler.method">GET</stringProp>
           <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
           <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
-          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="사용자 정의 변수들">
             <collectionProp name="Arguments.arguments"/>
           </elementProp>
         </HTTPSamplerProxy>
@@ -1555,7 +1555,7 @@
           <stringProp name="HTTPSampler.method">GET</stringProp>
           <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
           <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
-          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="사용자 정의 변수들">
             <collectionProp name="Arguments.arguments"/>
           </elementProp>
         </HTTPSamplerProxy>
@@ -1580,7 +1580,7 @@
           <stringProp name="HTTPSampler.method">GET</stringProp>
           <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
           <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
-          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="사용자 정의 변수들">
             <collectionProp name="Arguments.arguments"/>
           </elementProp>
         </HTTPSamplerProxy>
@@ -1605,7 +1605,7 @@
           <stringProp name="HTTPSampler.method">GET</stringProp>
           <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
           <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
-          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="사용자 정의 변수들">
             <collectionProp name="Arguments.arguments"/>
           </elementProp>
         </HTTPSamplerProxy>

--- a/src/main/java/project/forwork/api/domain/resume/controller/ResumeAdminController.java
+++ b/src/main/java/project/forwork/api/domain/resume/controller/ResumeAdminController.java
@@ -54,13 +54,14 @@ public class ResumeAdminController {
             @RequestParam(required = false) PeriodCond periodCond,
             @RequestParam(required = false) ResumeStatus status,
             @RequestParam(defaultValue = "FIRST") PageStep pageStep,
-            @RequestParam(required = false) LocalDateTime lastModifiedAt,
+            //@RequestParam(required = false) LocalDateTime lastModifiedAt,
             @RequestParam(required = false) Long lastId,
             @RequestParam(defaultValue = "6") int limit
     ) {
         // 필터링 및 페이징을 처리하는 서비스 호출
         ResumePage result = resumeService
-                .getFilteredAndPagedResults(periodCond, status, pageStep, lastModifiedAt, lastId, limit);
+                .getFilteredAndPagedResults(periodCond, status, pageStep, lastId, limit);
+        //.getFilteredAndPagedResults(periodCond, status, pageStep, lastModifiedAt, lastId, limit);
         return Api.OK(result);
     }
 }

--- a/src/main/java/project/forwork/api/domain/resume/controller/model/ResumeAdminResponse.java
+++ b/src/main/java/project/forwork/api/domain/resume/controller/model/ResumeAdminResponse.java
@@ -19,16 +19,5 @@ public class ResumeAdminResponse {
     private FieldType field;
     private LevelType level;
     private ResumeStatus status;
-    private LocalDateTime modifiedAt;
-
-    public static ResumeAdminResponse from(Resume resume){
-        return ResumeAdminResponse.builder()
-                .id(resume.getId())
-                .summary(resume.getDescription().substring(0, 15) + "...")
-                .field(resume.getField())
-                .level(resume.getLevel())
-                .status(resume.getStatus())
-                .modifiedAt(resume.getModifiedAt())
-                .build();
-    }
+    private LocalDateTime registeredAt;
 }

--- a/src/main/java/project/forwork/api/domain/resume/controller/model/ResumePage.java
+++ b/src/main/java/project/forwork/api/domain/resume/controller/model/ResumePage.java
@@ -11,6 +11,5 @@ import java.util.List;
 @NoArgsConstructor
 public class ResumePage {
     private Long lastId;
-    private LocalDateTime lastModifiedAt;
     private List<ResumeAdminResponse> results;
 }

--- a/src/main/java/project/forwork/api/domain/resume/controller/model/ResumeSellerResponse.java
+++ b/src/main/java/project/forwork/api/domain/resume/controller/model/ResumeSellerResponse.java
@@ -33,7 +33,7 @@ public class ResumeSellerResponse {
                 .field(resume.getField())
                 .level(resume.getLevel())
                 .status(resume.getStatus())
-                .modifiedAt(resume.getModifiedAt())
+                .modifiedAt(resume.getRegisteredAt())
                 .build();
     }
 }

--- a/src/main/java/project/forwork/api/domain/resume/infrastructure/ResumeEntity.java
+++ b/src/main/java/project/forwork/api/domain/resume/infrastructure/ResumeEntity.java
@@ -87,7 +87,7 @@ public class ResumeEntity extends BaseTimeEntity {
                 .description(description)
                 .status(resumeStatus)
                 .salesQuantity(salesQuantity)
-                .modifiedAt(getModifiedAt())
+                .registeredAt(getRegisteredAt())
                 .build();
     }
 }

--- a/src/main/java/project/forwork/api/domain/resume/infrastructure/ResumeRepositoryCustomImpl.java
+++ b/src/main/java/project/forwork/api/domain/resume/infrastructure/ResumeRepositoryCustomImpl.java
@@ -40,14 +40,14 @@ public class ResumeRepositoryCustomImpl implements ResumeRepositoryCustom {
                         resumeEntity.fieldType.as("field"),
                         resumeEntity.levelType.as("level"),
                         resumeEntity.resumeStatus.as("status"),
-                        resumeEntity.modifiedAt.as("modifiedAt"),
+                        resumeEntity.registeredAt.as("registeredAt"),
                         Expressions.stringTemplate("concat(substring({0}, 1, 10), '...')",
                                 resumeEntity.description).as("summary")))
                 .from(resumeEntity)
                 .where(dateRangeCond(periodCond),
                         resumeStatusEqual(status)
                 )
-                .orderBy(resumeEntity.modifiedAt.asc(), resumeEntity.id.asc())
+                .orderBy(resumeEntity.id.asc())
                 .limit(limit)
                 .fetch();
     }
@@ -61,14 +61,14 @@ public class ResumeRepositoryCustomImpl implements ResumeRepositoryCustom {
                         resumeEntity.fieldType.as("field"),
                         resumeEntity.levelType.as("level"),
                         resumeEntity.resumeStatus.as("status"),
-                        resumeEntity.modifiedAt.as("modifiedAt"),
+                        resumeEntity.registeredAt.as("registeredAt"),
                         Expressions.stringTemplate("concat(substring({0}, 1, 10), '...')",
                                 resumeEntity.description).as("summary")))
                 .from(resumeEntity)
                 .where(dateRangeCond(periodCond),
                         resumeStatusEqual(status)
                 )
-                .orderBy(resumeEntity.modifiedAt.desc(), resumeEntity.id.desc())
+                .orderBy(resumeEntity.id.desc())
                 .limit(limit)
                 .fetch();
 
@@ -80,7 +80,7 @@ public class ResumeRepositoryCustomImpl implements ResumeRepositoryCustom {
 
     public List<ResumeAdminResponse> findNextPage(
             PeriodCond periodCond, ResumeStatus status,
-            LocalDateTime lastModifiedAt, Long lastId, int limit
+            Long lastId, int limit
     ){
         return  queryFactory
                 .select(Projections.fields(ResumeAdminResponse.class,
@@ -88,24 +88,21 @@ public class ResumeRepositoryCustomImpl implements ResumeRepositoryCustom {
                         resumeEntity.fieldType.as("field"),
                         resumeEntity.levelType.as("level"),
                         resumeEntity.resumeStatus.as("status"),
-                        resumeEntity.modifiedAt.as("modifiedAt"),
+                        resumeEntity.registeredAt.as("registeredAt"),
                         Expressions.stringTemplate("concat(substring({0}, 1, 10), '...')",
                                 resumeEntity.description).as("summary")))
                 .from(resumeEntity)
                 .where(dateRangeCond(periodCond),
                         resumeStatusEqual(status),
-                        (resumeEntity.modifiedAt.eq(lastModifiedAt)
-                                .and(resumeEntity.id.gt(lastId)))
-                                 .or(resumeEntity.modifiedAt.gt(lastModifiedAt))
-                )
-                .orderBy(resumeEntity.modifiedAt.asc(), resumeEntity.id.asc())
+                        (resumeEntity.id.gt(lastId)))
+                .orderBy(resumeEntity.id.asc())
                 .limit(limit)
                 .fetch();
     }
 
     public List<ResumeAdminResponse> findPreviousPage(
             PeriodCond periodCond, ResumeStatus status,
-            LocalDateTime lastModifiedAt, Long lastId, int limit
+            Long lastId, int limit
     ){
         List<ResumeAdminResponse> results = queryFactory
                 .select(Projections.fields(ResumeAdminResponse.class,
@@ -113,17 +110,14 @@ public class ResumeRepositoryCustomImpl implements ResumeRepositoryCustom {
                         resumeEntity.fieldType.as("field"),
                         resumeEntity.levelType.as("level"),
                         resumeEntity.resumeStatus.as("status"),
-                        resumeEntity.modifiedAt.as("modifiedAt"),
+                        resumeEntity.registeredAt.as("registeredAt"),
                         Expressions.stringTemplate("concat(substring({0}, 1, 10), '...')",
                                 resumeEntity.description).as("summary")))
                 .from(resumeEntity)
                 .where(dateRangeCond(periodCond),
                         resumeStatusEqual(status),
-                        (resumeEntity.modifiedAt.eq(lastModifiedAt)
-                                .and(resumeEntity.id.lt(lastId)))
-                                .or(resumeEntity.modifiedAt.lt(lastModifiedAt))
-                )
-                .orderBy(resumeEntity.modifiedAt.desc(), resumeEntity.id.desc())
+                        (resumeEntity.id.lt(lastId)))
+                .orderBy(resumeEntity.id.desc())
                 .limit(limit)
                 .fetch();
 

--- a/src/main/java/project/forwork/api/domain/resume/model/Resume.java
+++ b/src/main/java/project/forwork/api/domain/resume/model/Resume.java
@@ -33,7 +33,7 @@ public class Resume {
     private Integer salesQuantity;
     private final String description;
     private final ResumeStatus status;
-    private final LocalDateTime modifiedAt;
+    private final LocalDateTime registeredAt;
 
 
     public static Resume from(User user, ResumeRegisterRequest body, String descriptionUrl){

--- a/src/main/java/project/forwork/api/domain/resume/service/ResumeService.java
+++ b/src/main/java/project/forwork/api/domain/resume/service/ResumeService.java
@@ -120,14 +120,15 @@ public class ResumeService {
 
     public ResumePage getFilteredAndPagedResults(
             PeriodCond periodCond, ResumeStatus status, PageStep pageStep,
-            LocalDateTime lastModifiedAt, Long lastId, int limit
+            //LocalDateTime lastModifiedAt, Long lastId, int limit
+            Long lastId, int limit
     ){
 
         return switch(pageStep){
             case FIRST -> findFirstPage(periodCond, status, limit);
             case LAST -> findLastPage(periodCond, status, limit);
-            case NEXT -> findNextPage(periodCond, status, lastModifiedAt, lastId, limit);
-            case PREVIOUS -> findPreviousPage(periodCond, status, lastModifiedAt, lastId, limit);
+            case NEXT -> findNextPage(periodCond, status, lastId, limit);
+            case PREVIOUS -> findPreviousPage(periodCond, status, lastId, limit);
         };
     }
 
@@ -150,18 +151,18 @@ public class ResumeService {
     @Transactional(readOnly = true)
     public ResumePage findNextPage(
             PeriodCond periodCond, ResumeStatus status,
-            LocalDateTime lastModifiedAt, Long lastId, int limit
+            Long lastId, int limit
     ){
-        List<ResumeAdminResponse> results = resumeRepositoryCustom.findNextPage(periodCond, status, lastModifiedAt, lastId, limit);
+        List<ResumeAdminResponse> results = resumeRepositoryCustom.findNextPage(periodCond, status, lastId, limit);
         return createResumePage(results);
     }
 
     @Transactional(readOnly = true)
     public ResumePage findPreviousPage(
             PeriodCond periodCond, ResumeStatus status,
-            LocalDateTime lastModifiedAt, Long lastId, int limit
+            Long lastId, int limit
     ){
-        List<ResumeAdminResponse> results = resumeRepositoryCustom.findPreviousPage(periodCond, status, lastModifiedAt, lastId, limit);
+        List<ResumeAdminResponse> results = resumeRepositoryCustom.findPreviousPage(periodCond, status, lastId, limit);
         return createReverseResumePage(results);
     }
 
@@ -200,7 +201,6 @@ public class ResumeService {
 
         return ResumePage.builder()
                 .lastId(lastRecord.getId())
-                .lastModifiedAt(lastRecord.getModifiedAt())
                 .results(results)
                 .build();
     }
@@ -215,7 +215,6 @@ public class ResumeService {
 
         return ResumePage.builder()
                 .results(results)
-                .lastModifiedAt(firstRecord.getModifiedAt())
                 .lastId(firstRecord.getId())
                 .build();
     }

--- a/src/main/java/project/forwork/api/domain/resume/service/port/ResumeRepositoryCustom.java
+++ b/src/main/java/project/forwork/api/domain/resume/service/port/ResumeRepositoryCustom.java
@@ -13,6 +13,6 @@ import java.util.List;
 public interface ResumeRepositoryCustom {
     List<ResumeAdminResponse> findFirstPage(PeriodCond periodCond, ResumeStatus status, int limit);
     List<ResumeAdminResponse> findLastPage(PeriodCond periodCond, ResumeStatus status, int limit);
-    List<ResumeAdminResponse> findNextPage(PeriodCond periodCond, ResumeStatus status, LocalDateTime lastModifiedAt, Long lastId, int limit);
-    List<ResumeAdminResponse> findPreviousPage(PeriodCond periodCond, ResumeStatus status, LocalDateTime lastModifiedAt, Long lastId, int limit);
+    List<ResumeAdminResponse> findNextPage(PeriodCond periodCond, ResumeStatus status, Long lastId, int limit);
+    List<ResumeAdminResponse> findPreviousPage(PeriodCond periodCond, ResumeStatus status, Long lastId, int limit);
 }

--- a/src/main/java/project/forwork/api/domain/salespost/infrastructure/SalesPostRepositoryCustomImpl.java
+++ b/src/main/java/project/forwork/api/domain/salespost/infrastructure/SalesPostRepositoryCustomImpl.java
@@ -177,8 +177,7 @@ public class SalesPostRepositoryCustomImpl implements SalesPostRepositoryCustom 
                 .select(Projections.fields(SalesPostQueryDto.class,
                         resumeEntity.salesQuantity.as("salesQuantity"),
                         resumeEntity.price.as("price"),
-                        resumeEntity.id.as("resumeId"),
-                        resumeEntity.modifiedAt.as("modifiedAt")
+                        resumeEntity.id.as("resumeId")
                 ))
                 .from(salesPostEntity)
                 .join(salesPostEntity.resumeEntity, resumeEntity)
@@ -190,9 +189,7 @@ public class SalesPostRepositoryCustomImpl implements SalesPostRepositoryCustom 
         SalesPostQueryDto salesPostDto = getSalesPostDto(lastId);
 
         if(SalesPostSortType.OLD.equals(sortType)){
-            return (resumeEntity.modifiedAt.eq(salesPostDto.getModifiedAt())
-                    .and(resumeEntity.id.gt(salesPostDto.getResumeId())))
-                    .or(resumeEntity.modifiedAt.gt(salesPostDto.getModifiedAt()));
+            return resumeEntity.id.gt(salesPostDto.getResumeId());
         }
 
         if(SalesPostSortType.LOWEST_PRICE.equals(sortType)){
@@ -214,19 +211,15 @@ public class SalesPostRepositoryCustomImpl implements SalesPostRepositoryCustom 
         }
 
         // NEW, DEFAULT
-        return (resumeEntity.modifiedAt.eq(salesPostDto.getModifiedAt())
-                .and(resumeEntity.id.lt(salesPostDto.getResumeId())))
-                .or(resumeEntity.modifiedAt.lt(salesPostDto.getModifiedAt()));
+        return resumeEntity.id.lt(salesPostDto.getResumeId());
     }
 
     private OrderSpecifier<?>[] createOrderSpecifier(SalesPostSortType sortType) {
         return switch (sortType) {
             case OLD -> new OrderSpecifier[] {
-                    new OrderSpecifier<>(Order.ASC, resumeEntity.modifiedAt),
                     new OrderSpecifier<>(Order.ASC, resumeEntity.id)
             };
             case NEW, DEFAULT -> new OrderSpecifier[] {
-                    new OrderSpecifier<>(Order.DESC, resumeEntity.modifiedAt),
                     new OrderSpecifier<>(Order.DESC, resumeEntity.id)
             };
             case HIGHEST_PRICE -> new OrderSpecifier[] {
@@ -249,9 +242,7 @@ public class SalesPostRepositoryCustomImpl implements SalesPostRepositoryCustom 
         SalesPostQueryDto salesPostDto = getSalesPostDto(lastId);
 
         if(SalesPostSortType.OLD.equals(sortType)){
-            return (resumeEntity.modifiedAt.eq(salesPostDto.getModifiedAt())
-                    .and(resumeEntity.id.lt(salesPostDto.getResumeId())))
-                    .or(resumeEntity.modifiedAt.lt(salesPostDto.getModifiedAt()));
+            return resumeEntity.id.lt(salesPostDto.getResumeId());
         }
 
         if(SalesPostSortType.LOWEST_PRICE.equals(sortType)){
@@ -272,19 +263,15 @@ public class SalesPostRepositoryCustomImpl implements SalesPostRepositoryCustom 
                     .or(resumeEntity.salesQuantity.gt(salesPostDto.getSalesQuantity()));
         }
         // NEW, DEFAULT
-        return (resumeEntity.modifiedAt.eq(salesPostDto.getModifiedAt())
-                .and(resumeEntity.id.gt(salesPostDto.getResumeId())))
-                .or(resumeEntity.modifiedAt.gt(salesPostDto.getModifiedAt()));
+        return resumeEntity.id.gt(salesPostDto.getResumeId());
     }
 
     private OrderSpecifier<?>[] createReversedOrderSpecifier(SalesPostSortType sortType) {
         return switch (sortType) {
             case OLD -> new OrderSpecifier[] {
-                    new OrderSpecifier<>(Order.DESC, resumeEntity.modifiedAt),
                     new OrderSpecifier<>(Order.DESC, resumeEntity.id)
             };
             case NEW, DEFAULT -> new OrderSpecifier[] {
-                    new OrderSpecifier<>(Order.ASC, resumeEntity.modifiedAt),
                     new OrderSpecifier<>(Order.ASC, resumeEntity.id)
             };
             case HIGHEST_PRICE -> new OrderSpecifier[] {

--- a/src/main/java/project/forwork/api/domain/salespost/infrastructure/model/SalesPostQueryDto.java
+++ b/src/main/java/project/forwork/api/domain/salespost/infrastructure/model/SalesPostQueryDto.java
@@ -14,5 +14,4 @@ public class SalesPostQueryDto {
     private Long resumeId;
     private BigDecimal price;
     private Integer salesQuantity;
-    private LocalDateTime modifiedAt;
 }

--- a/src/main/java/project/forwork/api/domain/user/controller/model/LoginResponse.java
+++ b/src/main/java/project/forwork/api/domain/user/controller/model/LoginResponse.java
@@ -5,6 +5,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import project.forwork.api.domain.token.model.TokenResponse;
+import project.forwork.api.domain.user.infrastructure.enums.UserStatus;
+import project.forwork.api.domain.user.model.User;
 
 @Getter
 @AllArgsConstructor
@@ -12,11 +14,13 @@ import project.forwork.api.domain.token.model.TokenResponse;
 @Builder
 public class LoginResponse {
     private Long userId;
+    private UserStatus status;
     private String accessToken;
 
-    public static LoginResponse from(Long userId, TokenResponse tokenResponse){
+    public static LoginResponse from(User user, TokenResponse tokenResponse){
         return LoginResponse.builder()
-                .userId(userId)
+                .userId(user.getId())
+                .status(user.getStatus())
                 .accessToken(tokenResponse.getAccessToken())
                 .build();
     }

--- a/src/main/java/project/forwork/api/domain/user/service/LoginService.java
+++ b/src/main/java/project/forwork/api/domain/user/service/LoginService.java
@@ -48,7 +48,7 @@ public class LoginService {
         String key = getKeyByLoginAttempt(user);
         initLoginAttemptCount(key);
 
-        return LoginResponse.from(user.getId(), tokenResponse);
+        return LoginResponse.from(user, tokenResponse);
     }
 
     public void logout(HttpServletResponse response){

--- a/src/test/java/project/forwork/api/domain/resume/infrastructure/ResumeRepositoryCustomImplTest.java
+++ b/src/test/java/project/forwork/api/domain/resume/infrastructure/ResumeRepositoryCustomImplTest.java
@@ -94,29 +94,13 @@ class ResumeRepositoryCustomImplTest {
         assertThat(result).hasSize(2);
     }
 
-    @Test
-    void 이력서_다음페이지_요청시간이_같다면_ID_값이_낮은게_먼저_반환_된다() {
-        //given(상황환경 세팅)
-        //2024-09-04 00:18:39
-        LocalDateTime last = LocalDateTime.of(2024, 9, 5, 0, 18, 39);
-
-        //when(상황발생)
-        List<ResumeAdminResponse> result = repository.findNextPage(null, null, last, 4L, 2);
-
-        //then(검증)
-        assertThat(result).hasSize(2);
-        assertThat(result.get(0).getId()).isEqualTo(5L);
-        assertThat(result.get(0).getModifiedAt()).isEqualTo(last);
-    }
-
 
     @Test
     void 이력서_다음페이지_조건_WEEK() {
         //given(상황환경 세팅) 2024-09-04 00:18:39
-        LocalDateTime last = LocalDateTime.of(2024, 9, 4, 0, 18, 39);
 
         //when(상황발생)
-        List<ResumeAdminResponse> result = repository.findNextPage(PeriodCond.WEEK, null, last, 3L, 2);
+        List<ResumeAdminResponse> result = repository.findNextPage(PeriodCond.WEEK, null, 3L, 2);
 
         //then(검증)
         assertThat(result).hasSize(2);
@@ -130,7 +114,7 @@ class ResumeRepositoryCustomImplTest {
         LocalDateTime last = LocalDateTime.of(2024, 9, 4, 0, 18, 39);
 
         //when(상황발생)
-        List<ResumeAdminResponse> result = repository.findNextPage(PeriodCond.WEEK, ResumeStatus.PENDING, last, 3L, 2);
+        List<ResumeAdminResponse> result = repository.findNextPage(PeriodCond.WEEK, ResumeStatus.PENDING, 3L, 2);
 
         //then(검증)
         assertThat(result).hasSize(0);
@@ -142,13 +126,13 @@ class ResumeRepositoryCustomImplTest {
         LocalDateTime last = LocalDateTime.of(2024, 9, 5, 0, 18, 39);
 
         //when(상황발생)
-        List<ResumeAdminResponse> result = repository.findNextPage(PeriodCond.MONTH, ResumeStatus.ACTIVE, last, 5L, 3);
+        List<ResumeAdminResponse> result = repository.findNextPage(PeriodCond.MONTH, ResumeStatus.ACTIVE, 5L, 3);
 
         //then(검증)
         assertThat(result).hasSize(3);
-        assertThat(result.get(0).getId()).isEqualTo(7L);
-        assertThat(result.get(1).getId()).isEqualTo(8L);
-        assertThat(result.get(2).getId()).isEqualTo(6L);
+        assertThat(result.get(0).getId()).isEqualTo(6L);
+        assertThat(result.get(1).getId()).isEqualTo(7L);
+        assertThat(result.get(2).getId()).isEqualTo(8L);
     }
 
     @Test
@@ -157,11 +141,11 @@ class ResumeRepositoryCustomImplTest {
         LocalDateTime last = LocalDateTime.of(2024, 9, 7, 0, 18, 39);
 
         //when(상황발생)
-        List<ResumeAdminResponse> result = repository.findPreviousPage(PeriodCond.WEEK, ResumeStatus.ACTIVE, last, 7L, 2);
+        List<ResumeAdminResponse> result = repository.findPreviousPage(PeriodCond.WEEK, ResumeStatus.ACTIVE, 7L, 2);
 
         //then(검증)
-        assertThat(result.get(0).getId()).isEqualTo(4L);
-        assertThat(result.get(1).getId()).isEqualTo(5L);
+        assertThat(result.get(0).getId()).isEqualTo(5L);
+        assertThat(result.get(1).getId()).isEqualTo(6L);
     }
 
     @Test
@@ -170,7 +154,7 @@ class ResumeRepositoryCustomImplTest {
         LocalDateTime last = LocalDateTime.of(2024, 9, 4, 0, 18, 39);
 
         //when(상황발생)
-        List<ResumeAdminResponse> result = repository.findPreviousPage(PeriodCond.MONTH, ResumeStatus.PENDING, last, 3L, 2);
+        List<ResumeAdminResponse> result = repository.findPreviousPage(PeriodCond.MONTH, ResumeStatus.PENDING, 3L, 2);
 
         //then(검증)
         assertThat(result.get(0).getId()).isEqualTo(1L);

--- a/src/test/java/project/forwork/api/domain/salepost/infrastructure/SalesPostRepositoryCustomImplTest.java
+++ b/src/test/java/project/forwork/api/domain/salepost/infrastructure/SalesPostRepositoryCustomImplTest.java
@@ -46,8 +46,8 @@ class SalesPostRepositoryCustomImplTest {
 
         //then(검증)
         assertThat(result).hasSize(2);
-        assertThat(result.get(0).getResumeId()).isEqualTo(6L);
-        assertThat(result.get(1).getResumeId()).isEqualTo(8L);
+        assertThat(result.get(0).getResumeId()).isEqualTo(8L);
+        assertThat(result.get(1).getResumeId()).isEqualTo(7L);
     }
 // 7,5,4,3,1 back
     @Test
@@ -141,8 +141,8 @@ class SalesPostRepositoryCustomImplTest {
 
         //then(검증)
         assertThat(result).hasSize(2);
-        assertThat(result.get(0).getResumeId()).isEqualTo(5L);
-        assertThat(result.get(1).getResumeId()).isEqualTo(4L);
+        assertThat(result.get(0).getResumeId()).isEqualTo(6L);
+        assertThat(result.get(1).getResumeId()).isEqualTo(5L);
     }
 
     @Test
@@ -155,8 +155,8 @@ class SalesPostRepositoryCustomImplTest {
 
         //then(검증)
         assertThat(result).hasSize(2);
-        assertThat(result.get(0).getResumeId()).isEqualTo(7L);
-        assertThat(result.get(1).getResumeId()).isEqualTo(8L);
+        assertThat(result.get(0).getResumeId()).isEqualTo(6L);
+        assertThat(result.get(1).getResumeId()).isEqualTo(7L);
     }
 
     @Test
@@ -257,7 +257,7 @@ class SalesPostRepositoryCustomImplTest {
 
         //then(검증)
         assertThat(result).hasSize(2);
-        assertThat(result.get(0).getResumeId()).isEqualTo(7L);
+        assertThat(result.get(0).getResumeId()).isEqualTo(6L);
         assertThat(result.get(1).getResumeId()).isEqualTo(5L);
     }
 
@@ -271,8 +271,8 @@ class SalesPostRepositoryCustomImplTest {
 
         //then(검증)
         assertThat(result).hasSize(2);
-        assertThat(result.get(0).getResumeId()).isEqualTo(8L);
-        assertThat(result.get(1).getResumeId()).isEqualTo(7L);
+        assertThat(result.get(0).getResumeId()).isEqualTo(7L);
+        assertThat(result.get(1).getResumeId()).isEqualTo(6L);
     }
 
     @Test


### PR DESCRIPTION
- 판매글 :  날짜순 조건을 수정일 기준으로 했는데 등록일 기준을 수정
- 이력서 요청 : 기존에는 modified_at과 함께 정렬을 헀지만 id 값만으로도 정렬을 할 수 있기 때문에 로직 수정
- 로그인시 상태 반환 추가
- Resolves: #174